### PR TITLE
Add unit and integration tests for MCP tools

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
@@ -31,10 +31,12 @@ public class ModelTools {
       @ToolParam(description = "Zusätzliche Imports (z. B. 'GeometryCHLV95_V1')") @Nullable List<String> imports
   ) {
       
-      var nv = NameValidator.ascii(); 
-      for (String m : imports) {
+      var nv = NameValidator.ascii();
+      if (imports != null) {
+        for (String m : imports) {
           nv.validateIdent(m, "Import model name");
         }
+      }
       
     String _lang = (lang == null || lang.isBlank()) ? "de" : lang.trim();
     String _version = (version == null || version.isBlank()) ? LocalDate.now(clock).toString() : version.trim();

--- a/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
@@ -1,0 +1,63 @@
+package ch.so.agi.mcp.integration;
+
+import ch.so.agi.mcp.tools.ModelTools;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ModelTools.class, ModelToolsIntegrationTest.FixedClockTestConfig.class})
+class ModelToolsIntegrationTest {
+
+    @TestConfiguration
+    static class FixedClockTestConfig {
+        @Bean(name = "testClock")
+        @Primary
+        Clock clock() {
+            return Clock.fixed(Instant.parse("2024-04-01T00:00:00Z"), ZoneId.of("UTC"));
+        }
+    }
+
+    @Autowired
+    private ModelTools modelTools;
+
+    @Test
+    void createModelSnippet_usesDefaultsFromSpringContext() {
+        Map<String, Object> result = modelTools.createModelSnippet("TestModel", null, null, null, null);
+
+        String expectedSnippet = "MODEL TestModel (de) AT \"https://example.org/testmodel\" VERSION \"2024-04-01\" =\n" +
+                "  IMPORTS UNQUALIFIED INTERLIS;\n\n" +
+                "END TestModel.\n";
+        assertEquals(expectedSnippet, result.get("iliSnippet"));
+        assertEquals(Map.of("line", 2, "col", 0), result.get("cursorHint"));
+    }
+
+    @Test
+    void createModelSnippet_trimsParametersAndJoinsImports() {
+        Map<String, Object> result = modelTools.createModelSnippet(
+                "DemoModel",
+                " en ",
+                " https://example.com/demo ",
+                "2023-12-31",
+                List.of("GeometryCHLV95_V1", "Units")
+        );
+
+        String expectedSnippet = "MODEL DemoModel (en) AT \"https://example.com/demo\" VERSION \"2023-12-31\" =\n" +
+                "  IMPORTS UNQUALIFIED GeometryCHLV95_V1, Units;\n\n" +
+                "END DemoModel.\n";
+        assertEquals(expectedSnippet, result.get("iliSnippet"));
+    }
+}

--- a/src/test/java/ch/so/agi/mcp/model/BaseTypeTest.java
+++ b/src/test/java/ch/so/agi/mcp/model/BaseTypeTest.java
@@ -1,0 +1,50 @@
+package ch.so.agi.mcp.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BaseTypeTest {
+
+    @Test
+    void validate_allowsTextWithoutLength() {
+        BaseType baseType = new BaseType();
+        baseType.setKind(BaseType.Kind.TEXT);
+        assertDoesNotThrow(baseType::validate);
+    }
+
+    @Test
+    void validate_rejectsTextWithInvalidLength() {
+        BaseType baseType = new BaseType();
+        baseType.setKind(BaseType.Kind.TEXT);
+        baseType.setLength(0);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, baseType::validate);
+        assertTrue(ex.getMessage().contains("length"));
+    }
+
+    @Test
+    void validate_numericRangeRequiresBounds() {
+        BaseType baseType = new BaseType();
+        baseType.setKind(BaseType.Kind.NUM_RANGE);
+        baseType.setMin(5.0);
+        baseType.setMax(10.0);
+        assertDoesNotThrow(baseType::validate);
+    }
+
+    @Test
+    void validate_numericRangeRejectsInvalidOrder() {
+        BaseType baseType = new BaseType();
+        baseType.setKind(BaseType.Kind.NUM_RANGE);
+        baseType.setMin(10.0);
+        baseType.setMax(5.0);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, baseType::validate);
+        assertTrue(ex.getMessage().contains("min < max"));
+    }
+
+    @Test
+    void validate_requiresKind() {
+        BaseType baseType = new BaseType();
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, baseType::validate);
+        assertTrue(ex.getMessage().contains("baseType.kind"));
+    }
+}

--- a/src/test/java/ch/so/agi/mcp/tools/AssociationToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/AssociationToolsTest.java
@@ -1,0 +1,57 @@
+package ch.so.agi.mcp.tools;
+
+import ch.so.agi.mcp.tools.AssociationTools.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AssociationToolsTest {
+
+    private final AssociationTools associationTools = new AssociationTools();
+
+    @Test
+    void createAssociation_formatsEachRoleOnOwnLine() {
+        Role left = new Role();
+        left.name = "from";
+        left.card = "{1}";
+        left.classFQN = "Mod.Topic.Source";
+
+        Role right = new Role();
+        right.name = "to";
+        right.card = "{0..*}";
+        right.classFQN = "Mod.Topic.Target";
+
+        Map<String, Object> response = associationTools.createAssociation("Link", List.of(left, right));
+
+        assertEquals(String.join("\n",
+                "ASSOCIATION Link =",
+                "  from -- {1} Mod.Topic.Source;",
+                "  to -- {0..*} Mod.Topic.Target;",
+                "END Link;"
+        ), response.get("iliSnippet"));
+        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
+    }
+
+    @Test
+    void createAssociation_validatesRoleNames() {
+        Role invalid = new Role();
+        invalid.name = "1bad";
+        invalid.card = "{1}";
+        invalid.classFQN = "Mod.Topic.Class";
+
+        Role other = new Role();
+        other.name = "good";
+        other.card = "{0..1}";
+        other.classFQN = "Mod.Topic.Other";
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                associationTools.createAssociation("Assoc", List.of(invalid, other))
+        );
+
+        assertTrue(ex.getMessage().contains("Association role name"));
+    }
+}
+

--- a/src/test/java/ch/so/agi/mcp/tools/AttributeToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/AttributeToolsTest.java
@@ -1,0 +1,67 @@
+package ch.so.agi.mcp.tools;
+
+import ch.so.agi.mcp.model.AttributeLineV2Request;
+import ch.so.agi.mcp.model.AttributeLineV2Request.Collection;
+import ch.so.agi.mcp.model.AttributeLineV2Response;
+import ch.so.agi.mcp.model.BaseType;
+import ch.so.agi.mcp.model.TypeSpec;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttributeToolsTest {
+
+    private final AttributeTools attributeTools = new AttributeTools();
+
+    @Test
+    void createAttributeLineV2_usesDomainWhenPresent() {
+        AttributeLineV2Request request = new AttributeLineV2Request();
+        request.setName("farbe");
+        TypeSpec spec = new TypeSpec();
+        spec.setDomainFqn("Demo.Core.Farbe");
+        request.setTypeSpec(spec);
+
+        AttributeLineV2Response response = attributeTools.createAttributeLineV2(request);
+
+        assertEquals("farbe : Demo.Core.Farbe;", response.getIliSnippet());
+        assertEquals(0, response.getCursorHint().get("line"));
+        assertEquals(0, response.getCursorHint().get("col"));
+    }
+
+    @Test
+    void createAttributeLineV2_formatsBaseTypeRange() {
+        AttributeLineV2Request request = new AttributeLineV2Request();
+        request.setName("hoehe");
+        request.setMandatory(true);
+        request.setCollection(Collection.LIST_OF);
+
+        BaseType baseType = new BaseType();
+        baseType.setKind(BaseType.Kind.NUM_RANGE);
+        baseType.setMin(0.0);
+        baseType.setMax(100.0);
+        baseType.setUnitFqn("INTERLIS.m");
+
+        TypeSpec spec = new TypeSpec();
+        spec.setBaseType(baseType);
+        request.setTypeSpec(spec);
+
+        AttributeLineV2Response response = attributeTools.createAttributeLineV2(request);
+
+        assertEquals("hoehe : MANDATORY LIST OF 0.0 .. 100.0 [INTERLIS.m];", response.getIliSnippet());
+    }
+
+    @Test
+    void createAttributeLineV2_rejectsInvalidAttributeName() {
+        AttributeLineV2Request request = new AttributeLineV2Request();
+        request.setName("1invalid");
+        TypeSpec spec = new TypeSpec();
+        BaseType baseType = new BaseType();
+        baseType.setKind(BaseType.Kind.BOOLEAN);
+        spec.setBaseType(baseType);
+        request.setTypeSpec(spec);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> attributeTools.createAttributeLineV2(request));
+        assertTrue(ex.getMessage().contains("Attribute name"));
+    }
+}

--- a/src/test/java/ch/so/agi/mcp/tools/ClassToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ClassToolsTest.java
@@ -1,0 +1,61 @@
+package ch.so.agi.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClassToolsTest {
+
+    private final ClassTools classTools = new ClassTools();
+
+    @Test
+    void createClass_buildsAbstractExtendingSnippetWithAttributes() {
+        Map<String, Object> response = classTools.createClass(
+                "Baum",
+                true,
+                "Basis.Top.Tree",
+                "OID AS UUIDOID",
+                List.of("art : TEXT;", "hoehe : 0 .. 20;")
+        );
+
+        String expected = String.join("\n",
+                "CLASS Baum (ABSTRACT) EXTENDS Basis.Top.Tree =",
+                "  OID AS UUIDOID;",
+                "  art : TEXT;",
+                "  hoehe : 0 .. 20;",
+                "END Baum;"
+        );
+        assertEquals(expected, response.get("iliSnippet"));
+        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
+    }
+
+    @Test
+    void createClass_usesPlaceholderWhenNoAttributes() {
+        Map<String, Object> response = classTools.createClass(
+                "Strauch",
+                false,
+                null,
+                null,
+                List.of()
+        );
+
+        assertEquals(String.join("\n",
+                "CLASS Strauch =",
+                "  !! Attribute hier",
+                "END Strauch;"
+        ), response.get("iliSnippet"));
+    }
+
+    @Test
+    void createClass_rejectsInvalidExtendsFqn() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                classTools.createClass("Test", null, "invalid fq", null, null)
+        );
+
+        assertTrue(ex.getMessage().contains("EXTENDS FQN"));
+    }
+}
+

--- a/src/test/java/ch/so/agi/mcp/tools/ConstraintToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ConstraintToolsTest.java
@@ -1,0 +1,47 @@
+package ch.so.agi.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConstraintToolsTest {
+
+    private final ConstraintTools constraintTools = new ConstraintTools();
+
+    @Test
+    void uniqueConstraint_trimsAttributesAndJoinsWithComma() {
+        Map<String, Object> response = constraintTools.unique(List.of("  name  ", "lage"));
+
+        assertEquals(String.join("\n",
+                "CONSTRAINTS",
+                "  UNIQUE (name, lage);"
+        ), response.get("iliSnippet"));
+        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
+    }
+
+    @Test
+    void setConstraint_indentsExpression() {
+        Map<String, Object> response = constraintTools.setConstraint("AREA->STANDORT->count() > 0");
+
+        assertEquals(String.join("\n",
+                "CONSTRAINTS",
+                "  SET CONSTRAINT",
+                "    AREA->STANDORT->count() > 0;"
+        ), response.get("iliSnippet"));
+        assertEquals(Map.of("line", 2, "col", 4), response.get("cursorHint"));
+    }
+
+    @Test
+    void existenceConstraint_joinsFqns() {
+        Map<String, Object> response = constraintTools.existence("obj.ref", List.of("Mod1.ClassA", "Mod2.ClassB"));
+
+        assertEquals(String.join("\n",
+                "CONSTRAINTS",
+                "  EXISTENCE CONSTRAINT obj.ref REQUIRED IN Mod1.ClassA, Mod2.ClassB;"
+        ), response.get("iliSnippet"));
+    }
+}
+

--- a/src/test/java/ch/so/agi/mcp/tools/StructureToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/StructureToolsTest.java
@@ -1,0 +1,42 @@
+package ch.so.agi.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StructureToolsTest {
+
+    private final StructureTools structureTools = new StructureTools();
+
+    @Test
+    void createStructure_includesExtendsAndAttributes() {
+        Map<String, Object> response = structureTools.createStructure(
+                "Adresse",
+                false,
+                "Basis.Adresse",
+                List.of("plz : 4 .. 5;")
+        );
+
+        assertEquals(String.join("\n",
+                "STRUCTURE Adresse EXTENDS Basis.Adresse =",
+                "  plz : 4 .. 5;",
+                "END Adresse;"
+        ), response.get("iliSnippet"));
+        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
+    }
+
+    @Test
+    void createStructure_usesPlaceholderWhenNoAttributes() {
+        Map<String, Object> response = structureTools.createStructure("Koordinate", true, null, null);
+
+        assertEquals(String.join("\n",
+                "STRUCTURE Koordinate (ABSTRACT) =",
+                "  !! Attribute hier",
+                "END Koordinate;"
+        ), response.get("iliSnippet"));
+    }
+}
+

--- a/src/test/java/ch/so/agi/mcp/tools/TopicToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/TopicToolsTest.java
@@ -1,0 +1,33 @@
+package ch.so.agi.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TopicToolsTest {
+
+    private final TopicTools topicTools = new TopicTools();
+
+    @Test
+    void createTopic_includesOidWhenProvided() {
+        Map<String, Object> response = topicTools.createTopic("Geo", "OID AS OIDTYPE", false);
+
+        assertEquals(String.join("\n",
+                "TOPIC Geo =",
+                "  OID AS OIDTYPE;",
+                "  !! Klassen/Assoziationen hier",
+                "END Geo;"
+        ), response.get("iliSnippet"));
+        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
+    }
+
+    @Test
+    void createTopic_marksAbstractWhenRequested() {
+        Map<String, Object> response = topicTools.createTopic("Verkehr", null, true);
+
+        assertTrue(response.get("iliSnippet").toString().startsWith("TOPIC Verkehr (ABSTRACT) ="));
+    }
+}
+

--- a/src/test/java/ch/so/agi/mcp/util/NameValidatorTest.java
+++ b/src/test/java/ch/so/agi/mcp/util/NameValidatorTest.java
@@ -1,0 +1,36 @@
+package ch.so.agi.mcp.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NameValidatorTest {
+
+    @Test
+    void asciiValidator_acceptsSimpleIdentifier() {
+        NameValidator.ascii().validateIdent("Model1", "Model name");
+    }
+
+    @Test
+    void asciiValidator_rejectsInvalidIdentifier() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> NameValidator.ascii().validateIdent("1Model", "Model name")
+        );
+        assertTrue(ex.getMessage().contains("Model name"));
+    }
+
+    @Test
+    void validateFqn_acceptsCompoundName() {
+        NameValidator.ascii().validateFqn("Model.Topic.Class", "Class FQN");
+    }
+
+    @Test
+    void validateFqn_rejectsEmptySegment() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> NameValidator.ascii().validateFqn("Model..Class", "Class FQN")
+        );
+        assertTrue(ex.getMessage().contains("Class FQN"));
+    }
+}


### PR DESCRIPTION
## Summary
- guard createModelSnippet against null imports and keep validation for provided names
- add focused unit tests for NameValidator, BaseType, and AttributeTools
- add integration-style test ensuring ModelTools uses injected Clock defaults and parameter trimming
- add snippet-generation tests for ClassTools, TopicTools, StructureTools, ConstraintTools, and AssociationTools

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d030e820a48328ba62dc8ef3ae2285