### PR TITLE
Add Docker packaging for stdio MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: compile the application using the Gradle wrapper and JDK 21
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+# Copy build configuration and sources
+COPY gradle/ gradle/
+COPY gradlew settings.gradle build.gradle ./
+COPY src/ src/
+
+# Ensure the Gradle wrapper is executable and build the application
+RUN chmod +x gradlew \
+    && ./gradlew bootJar --no-daemon
+
+# Runtime stage: use a slim JRE to execute the MCP server
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+# Create an unprivileged user that will run the MCP server
+RUN useradd --create-home --shell /usr/sbin/nologin appuser
+
+# Copy the built jar from the build stage and assign it to the app user
+COPY --from=build --chown=appuser:appuser /workspace/build/libs/mcp-interlis.jar ./mcp-interlis.jar
+
+USER appuser
+
+# Keep the Java process attached to STDIN/STDOUT so MCP clients can communicate via stdio
+ENTRYPOINT ["java", "-jar", "/app/mcp-interlis.jar"]

--- a/README.md
+++ b/README.md
@@ -18,5 +18,20 @@
 
 - Claude GUI
 - VSCode mit eigenem Agent und Systemprompts o.ä.
-- theia statt vscode?   
-- 
+- theia statt vscode?
+ 
+## Docker
+
+Build the container image locally:
+
+```bash
+docker build -t interlis-mcp .
+```
+
+Run the MCP server with standard input/output connected to your host:
+
+```bash
+docker run --rm -i interlis-mcp
+```
+
+Because the MCP transport is STDIO-based you should not allocate a TTY (no `-t`) and must keep standard input open (the `-i` flag). For Docker Compose set `stdin_open: true` and `tty: false` on the service so that tools can exchange JSON-RPC messages with the server without any extra escape sequences.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the MCP server jar and runs it with stdio-capable entrypoint
- add a .dockerignore to keep the build context small
- document how to build and run the container image with the required stdio flags

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ecb22a0b6883289f23e864e8699cfd