### PR TITLE
Add user and developer documentation for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
 # interlis-mcp
 
- 
-## Docker
+`interlis-mcp` is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that helps large language models author correct INTERLIS 2 model definitions. It exposes a catalogue of Spring AI tools for building model, topic, domain, class, association, structure, attribute, constraint, and identifier snippets that IDE assistants can assemble into complete schemas.
 
+## Overview
+- ✅ STDIO-based MCP server built with Spring Boot and Spring AI's MCP starter.
+- ✅ Tooling focused on generating valid INTERLIS snippets and validating identifiers.
+- ✅ Ready to plug into Claude Desktop, VS Code MCP clients, or any MCP-compliant agent runtime.
+
+## Architecture at a glance
+```mermaid
+flowchart LR
+    Client["MCP client (Claude Desktop, VS Code, etc.)"]
+    Runtime["MCP runtime / transport\n(JSON-RPC over STDIO)"]
+    Server["interlis-mcp server\n(Spring Boot + Spring AI)"]
+    Registry["MethodToolCallbackProvider\nregistered tools"]
+    Ili["INTERLIS snippet / validation output"]
+
+    Client --> Runtime --> Server --> Registry --> Ili
+```
+
+## Quick start
+
+### Run from source
+1. Ensure a JDK 21 runtime is available (the Gradle build configures the Java toolchain accordingly).
+2. Build the application:
+   ```bash
+   ./gradlew bootJar
+   ```
+3. Start the MCP server with STDIO transport:
+   ```bash
+   java -jar build/libs/interlis-mcp.jar
+   ```
+   The process remains attached to your terminal because MCP communicates via STDIN/STDOUT.
+
+### Docker
 Build the container image locally:
 
 ```bash
@@ -16,3 +47,14 @@ docker run --rm -i interlis-mcp
 ```
 
 Because the MCP transport is STDIO-based you should not allocate a TTY (no `-t`) and must keep standard input open (the `-i` flag). For Docker Compose set `stdin_open: true` and `tty: false` on the service so that tools can exchange JSON-RPC messages with the server without any extra escape sequences.
+
+## Connect from MCP clients
+- **Claude Desktop** – register the executable or Docker command under *Settings → Developer → MCP tools*. Detailed steps are documented in [docs/USER_GUIDE.md](docs/USER_GUIDE.md#claude-desktop).
+- **VS Code** – add the server command to the Model Context Protocol extension settings (see [docs/USER_GUIDE.md](docs/USER_GUIDE.md#visual-studio-code)).
+
+## Documentation
+- [User Guide](docs/USER_GUIDE.md) – startup instructions, client configuration, and a complete tool reference.
+- [Developer Guide](docs/DEVELOPER_GUIDE.md) – build, test, and extension notes for contributors.
+
+## License
+[MIT](LICENSE)

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,54 @@
+# Developer Guide
+
+This document supports contributors who want to build, test, and extend the `interlis-mcp` server.
+
+## Project structure
+- **Spring Boot application** – `Application` starts the STDIO-only Spring context that hosts the MCP server. `spring.main.web-application-type=none` disables the web container so the process only reads and writes via STDIN/STDOUT.
+- **Tool beans** – Classes in `ch.so.agi.mcp.tools` expose MCP tools using `@Tool` annotations. `ToolsConfig` registers all tool beans with Spring AI's `MethodToolCallbackProvider`, making each annotated method callable by clients.
+- **Model classes** – Types in `ch.so.agi.mcp.model` define the JSON payloads for complex tools such as `createAttributeLineV2`.
+- **Utility classes** – `NameValidator` centralizes identifier validation logic shared by multiple tools.
+
+## Build and run
+```bash
+./gradlew bootJar
+java -jar build/libs/interlis-mcp.jar
+```
+The Gradle build configures a Java 21 toolchain, names the Boot archive `interlis-mcp.jar`, and depends on `spring-ai-starter-mcp-server` to provide the MCP runtime wiring. During iteration you can run `./gradlew bootRun` to start the STDIO server without packaging.
+
+## Testing
+- Unit tests: `./gradlew test`
+- End-to-end tests (tagged `@Tag("e2e")`): `./gradlew e2eTest`
+
+Both tasks use JUnit Platform configuration defined in `build.gradle`.
+
+## Configuration
+Application-level settings live in `src/main/resources/application.properties`:
+- Declares the MCP server name (`interlis-mcp`), version (`0.1.0`), and that only tool capabilities are enabled.
+- Enables STDIO transport (`spring.ai.mcp.server.stdio=true`) and disables other MCP feature sets (resources, prompts, completions).
+- Silences Spring Boot logging for cleaner STDIO channels.
+
+Adjust these properties if you change metadata or add new capability types.
+
+## Tool registry
+All tools are wired through `ToolsConfig`, which injects each `@Component` tool class into a single `MethodToolCallbackProvider`. Adding a new tool only requires:
+1. Creating a Spring component under `ch.so.agi.mcp.tools`.
+2. Annotating public methods with `@Tool` and declaring parameters with `@ToolParam` (or POJO payloads).
+3. Ensuring the component is listed in the `toolObjects` builder call.
+
+Spring AI converts incoming MCP JSON-RPC payloads into method arguments and serializes return values back to the client.
+
+## Data contracts
+For attribute creation the server uses rich DTOs:
+- `AttributeLineV2Request` carries the attribute name, optional mandatory flag, optional collection, and a mutually exclusive `typeSpec`.
+- `TypeSpec` enforces that either `domainFqn` or `baseType` is provided.
+- `BaseType` supplies strong validation for numeric ranges, text lengths, and supported primitive kinds.
+- `AttributeLineV2Response` standardizes the returned snippet and cursor hint map.
+Re-use these classes when introducing new tools that work with attributes to stay consistent with existing validation logic.
+
+## Docker packaging
+The Gradle build delegates to `gradle/docker.gradle` so you can run `docker build -t interlis-mcp .` from the repository root. The resulting image launches the STDIO server immediately, making it convenient for MCP clients that manage tools as container commands.
+
+## Coding guidelines
+- Prefer `NameValidator.ascii()` to enforce classic INTERLIS identifier rules when accepting names or FQNs.
+- Throw informative `IllegalArgumentException`s so MCP clients can surface actionable errors.
+- Return `cursorHint` positions whenever you can to help editors position user cursors after inserting snippets.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,112 @@
+# User Guide
+
+This guide explains how to start the `interlis-mcp` server, connect it to common MCP clients, and call the INTERLIS tooling functions it exposes.
+
+## Prerequisites
+- Java 21 runtime (Gradle automatically provisions a Java 21 toolchain for builds). 
+- Optional: Docker if you prefer containerized execution.
+
+## Starting the server
+
+### Build and run with Gradle
+1. Compile the executable JAR:
+   ```bash
+   ./gradlew bootJar
+   ```
+2. Launch the STDIO MCP server:
+   ```bash
+   java -jar build/libs/interlis-mcp.jar
+   ```
+   Keep the process attached to your terminal. MCP clients communicate with the server through standard input and output streams.
+
+### Run straight from Gradle (development)
+During development you can start the server without building the JAR:
+```bash
+./gradlew bootRun
+```
+Gradle will launch the Spring Boot application in STDIO mode using the configuration from `src/main/resources/application.properties`.
+
+### Run with Docker
+Follow the Docker instructions from the project README:
+```bash
+docker build -t interlis-mcp .
+docker run --rm -i interlis-mcp
+```
+Ensure `stdin_open` remains true and no TTY is allocated so the MCP JSON-RPC stream stays intact.
+
+## Connecting clients
+
+### Claude Desktop
+1. Start the server locally (JAR, Gradle, or Docker).
+2. Open **Claude Desktop → Settings → Developer → Model Context Protocol tools**.
+3. Click **Add tool** and provide:
+   - **Name**: `interlis-mcp`
+   - **Command**: the invocation you use locally, for example `java -jar /path/to/interlis-mcp.jar` or `docker run --rm -i interlis-mcp`.
+   - Leave transport as STDIO (default).
+4. Save the tool and enable it for the conversations where you want INTERLIS support.
+5. Claude can now call the registered tools whenever it needs snippets or validation logic.
+
+### Visual Studio Code
+1. Install an MCP-capable extension such as *Model Context Protocol* from the VS Code Marketplace.
+2. Start the `interlis-mcp` server command (JAR or Docker) or reference it in the extension configuration.
+3. Add an entry to your VS Code settings (JSON) similar to:
+   ```json
+   "modelContextProtocol.servers": {
+     "interlis-mcp": {
+       "command": "java",
+       "args": ["-jar", "/absolute/path/to/interlis-mcp.jar"]
+     }
+   }
+   ```
+4. Reload VS Code so the extension spawns the MCP server. Tool calls now appear inside the chat or coding assistant UI.
+
+## Tool reference
+The server registers all tools in `ToolsConfig` and advertises itself as an STDIO, tool-capable MCP endpoint. Each tool returns an object that at least contains `iliSnippet` (the generated INTERLIS fragment) and, where applicable, a `cursorHint` map indicating where to place the caret in editors.
+
+### Model and topic helpers
+- **`createModelSnippet`** – Generate a model skeleton (`MODEL … END`). Parameters: `name` (required), optional `lang`, `uri`, `version`, and additional `imports`. Defaults fill in `lang="de"`, `version=today`, and `uri=https://example.org/<name>`. Returns `iliSnippet` and a cursor hint pointing to the import section.
+- **`createTopicSnippet`** – Produce a `TOPIC` block. Parameters: `name` (required), optional `oidType` declaration, and `isAbstract` flag. Returns snippet with placeholder comment for classes.
+
+### Domains and units
+- **`createEnumDomainSnippet`** – Emit a `DOMAIN` definition with enumerated items. Provide `name` and an ordered list of `items`.
+- **`createNumericDomainSnippet`** – Emit a `DOMAIN` for numeric ranges with optional unit (`unitFqn`). Requires `name`, `min`, and `max`.
+- **`createUnitSnippet`** – Define a custom unit by specifying `name`, `kind` (e.g., `LENGTH`), and base unit (`INTERLIS.m`, etc.).
+
+### Class and structure builders
+- **`createClassSnippet`** – Build a `CLASS` block with optional abstract flag, `EXTENDS` clause, `OID` declaration, and optional attribute lines. Supplying `attrLines` inserts raw INTERLIS lines; otherwise a placeholder comment is inserted.
+- **`createStructureSnippet`** – Analogous to `createClassSnippet` but for `STRUCTURE` definitions without OIDs.
+- **`createAssociationSnippet`** – Create an `ASSOCIATION` with role descriptors. Provide `name` and at least two `roles` (each role carries `name`, `classFQN`, and `card`).
+
+### Attribute helpers
+- **`createAttributeLineV2`** – Preferred endpoint for a single attribute line. Accepts an object with fields:
+  - `name` (identifier),
+  - optional `mandatory` boolean,
+  - optional `collection` (`NONE`, `LIST_OF`, `BAG_OF`),
+  - `typeSpec` which must contain **either** `domainFqn` or a `baseType` object.
+    - `baseType` requires `kind` (`TEXT`, `MTEXT`, `NUM_RANGE`, `BOOLEAN`, `COORD`, `POLYLINE`, `SURFACE_SIMPLE`).
+    - Numeric ranges need `min`, `max`, and optional `unitFqn`.
+    - Text kinds accept optional `length`.
+  Returns the attribute line and default cursor hint `{line:0, col:0}`.
+- **`createStructureAttributeLine`** – Emit an attribute referencing a `STRUCTURE`. Parameters: `name`, `structureFqn`, optional `mandatory`, and optional `collection` (`NONE`, `LIST_OF`, `BAG_OF`).
+- **Deprecated** – `createAttributeLine` and `createSnippet` exist for backward compatibility and immediately throw a descriptive error advising you to use the newer variants.
+
+### Constraint helpers
+- **`createUniqueConstraint`** – Wrap attribute names in a `CONSTRAINTS` block with `UNIQUE`.
+- **`createMandatoryConstraint`** – Build a `MANDATORY CONSTRAINT` with an arbitrary boolean expression.
+- **`createSetConstraint`** – Produce a `SET CONSTRAINT` block with a multi-line expression.
+- **`createPresentIfConstraint`** – Ensure an attribute is present under a condition.
+- **`createValueRangeConstraint`** – Restrict an attribute to a specified range.
+- **`createExistenceConstraint`** – Require a reference attribute to point to one of the provided class FQNs.
+
+### Identifier utilities
+- **`sanitizeIdentifier`** – Convert arbitrary strings into legal INTERLIS identifiers (letters, digits, underscores) and report whether the value was changed.
+- **`validateIdentifier`** – Throw if the supplied identifier violates `^[A-Za-z][A-Za-z0-9_]*$`; otherwise return `{valid:true}`.
+- **`validateFqn`** – Validate a dot-separated fully qualified name and return `{valid:true}` on success.
+
+## Server metadata
+The MCP metadata advertises the server name, version, and capabilities. Tools are registered through Spring's `MethodToolCallbackProvider` so all annotated beans under `ch.so.agi.mcp.tools` become available to clients.
+
+## Tips
+- Tool parameters use standard MCP JSON serialization—send lists and objects exactly as shown in the descriptions above.
+- Many helpers validate identifiers and FQNs before emitting snippets, returning descriptive errors that MCP clients can surface to users.
+- Use the returned `cursorHint` coordinates to position the editor caret after inserting generated snippets.


### PR DESCRIPTION
## Summary
- expand the README with an overview, architecture diagram, quick-start steps, and links to detailed guides
- document end-user workflows for starting the server, wiring Claude Desktop and VS Code, and referencing every MCP tool
- add a developer guide covering project structure, build/test commands, configuration, and extension tips

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68eccc512fb08328be6b59a981c86328