### PR TITLE
Rename attribute line DTOs and remove legacy tool

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -39,10 +39,10 @@ Spring AI converts incoming MCP JSON-RPC payloads into method arguments and seri
 
 ## Data contracts
 For attribute creation the server uses rich DTOs:
-- `AttributeLineV2Request` carries the attribute name, optional mandatory flag, optional collection, and a mutually exclusive `typeSpec`.
+- `AttributeLineRequest` carries the attribute name, optional mandatory flag, optional collection, and a mutually exclusive `typeSpec`.
 - `TypeSpec` enforces that either `domainFqn` or `baseType` is provided.
 - `BaseType` supplies strong validation for numeric ranges, text lengths, and supported primitive kinds.
-- `AttributeLineV2Response` standardizes the returned snippet and cursor hint map.
+- `AttributeLineResponse` standardizes the returned snippet and cursor hint map.
 Re-use these classes when introducing new tools that work with attributes to stay consistent with existing validation logic.
 
 ## Docker packaging

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -87,7 +87,6 @@ The server registers all tools in `ToolsConfig` and advertises itself as an STDI
     - Text kinds accept optional `length`.
   Returns the attribute line and default cursor hint `{line:0, col:0}`.
 - **`createStructureAttributeLine`** – Emit an attribute referencing a `STRUCTURE`. Parameters: `name`, `structureFqn`, optional `mandatory`, and optional `collection` (`NONE`, `LIST_OF`, `BAG_OF`).
-- **Deprecated** – `createAttributeLine` and `createSnippet` exist for backward compatibility and immediately throw a descriptive error advising you to use the newer variants.
 
 ### Constraint helpers
 - **`createUniqueConstraint`** – Wrap attribute names in a `CONSTRAINTS` block with `UNIQUE`.

--- a/src/main/java/ch/so/agi/mcp/model/AttributeLineRequest.java
+++ b/src/main/java/ch/so/agi/mcp/model/AttributeLineRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Pattern;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class AttributeLineV2Request {
+public class AttributeLineRequest {
 
   public enum Collection { NONE, LIST_OF, BAG_OF }
 

--- a/src/main/java/ch/so/agi/mcp/model/AttributeLineResponse.java
+++ b/src/main/java/ch/so/agi/mcp/model/AttributeLineResponse.java
@@ -2,13 +2,13 @@ package ch.so.agi.mcp.model;
 
 import java.util.Map;
 
-public class AttributeLineV2Response {
+public class AttributeLineResponse {
   private String iliSnippet;
   private Map<String,Integer> cursorHint;
 
-  public AttributeLineV2Response() {}
+  public AttributeLineResponse() {}
 
-  public AttributeLineV2Response(String iliSnippet) {
+  public AttributeLineResponse(String iliSnippet) {
     this.iliSnippet = iliSnippet;
     this.cursorHint = Map.of("line", 0, "col", 0);
   }

--- a/src/main/java/ch/so/agi/mcp/tools/AttributeTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/AttributeTools.java
@@ -1,7 +1,7 @@
 package ch.so.agi.mcp.tools;
 
 import ch.so.agi.mcp.model.*;
-import ch.so.agi.mcp.model.AttributeLineV2Request.Collection;
+import ch.so.agi.mcp.model.AttributeLineRequest.Collection;
 import ch.so.agi.mcp.util.NameValidator;
 
 import org.springframework.ai.tool.annotation.Tool;
@@ -12,8 +12,8 @@ public class AttributeTools {
 
   /**
    * New, strict version that prevents illegal types like bare "NUMERIC".
-   * Input: AttributeLineV2Request (name, mandatory?, collection?, typeSpec oneOf).
-   * Output: AttributeLineV2Response with a single ILI line.
+   * Input: AttributeLineRequest (name, mandatory?, collection?, typeSpec oneOf).
+   * Output: AttributeLineResponse with a single ILI line.
    */
   @Tool(
       name = "createAttributeLineV2",
@@ -26,7 +26,7 @@ public class AttributeTools {
         - Domain: {"domainFqn":"Demo.Farbe"}
         """
   )
-  public AttributeLineV2Response createAttributeLineV2(AttributeLineV2Request req) {
+  public AttributeLineResponse createAttributeLineV2(AttributeLineRequest req) {
     // ---- basic checks
     if (req.getName() == null || req.getName().isBlank()) {
       throw new IllegalArgumentException("Attribute 'name' is required.");
@@ -81,22 +81,6 @@ public class AttributeTools {
     };
 
     String line = req.getName().trim() + " : " + prefix + collectionPrefix + rhs + ";";
-    return new AttributeLineV2Response(line);
-  }
-
-  /**
-   * Optional: keep the old tool name as a strict adapter that FAILS on illegal strings.
-   * If you must keep legacy shape {name, type, ...}, you can parse and forward.
-   * Here we recommend returning a helpful error instead of guessing.
-   */
-  @Tool(
-      name = "createAttributeLine",
-      description = "Deprecated legacy tool. Please use createAttributeLineV2. " +
-                    "This legacy endpoint rejects bare NUMERIC and unknown types."
-  )
-  public AttributeLineV2Response createAttributeLineLegacy(String name, String type) {
-    throw new IllegalArgumentException(
-        "Deprecated: use createAttributeLineV2 with a 'typeSpec'. " +
-        "Bare 'NUMERIC' is not valid in INTERLIS; use baseType.NUM_RANGE with min/max or a domainFqn.");
+    return new AttributeLineResponse(line);
   }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
@@ -57,13 +57,4 @@ public class ModelTools {
     );
   }
 
-  /** Deprecated alias kept for backward compatibility */
-  @Deprecated
-  @Tool(name = "createSnippet", description = "Deprecated alias of createModelSnippet.")
-  public Map<String, Object> createSnippetAlias(
-      String name, @Nullable String lang, @Nullable String uri,
-      @Nullable String version, @Nullable List<String> imports
-  ) {
-    return createModelSnippet(name, lang, uri, version, imports);
-  }
 }

--- a/src/test/java/ch/so/agi/mcp/tools/AttributeToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/AttributeToolsTest.java
@@ -1,8 +1,8 @@
 package ch.so.agi.mcp.tools;
 
-import ch.so.agi.mcp.model.AttributeLineV2Request;
-import ch.so.agi.mcp.model.AttributeLineV2Request.Collection;
-import ch.so.agi.mcp.model.AttributeLineV2Response;
+import ch.so.agi.mcp.model.AttributeLineRequest;
+import ch.so.agi.mcp.model.AttributeLineRequest.Collection;
+import ch.so.agi.mcp.model.AttributeLineResponse;
 import ch.so.agi.mcp.model.BaseType;
 import ch.so.agi.mcp.model.TypeSpec;
 import org.junit.jupiter.api.Test;
@@ -15,13 +15,13 @@ class AttributeToolsTest {
 
     @Test
     void createAttributeLineV2_usesDomainWhenPresent() {
-        AttributeLineV2Request request = new AttributeLineV2Request();
+        AttributeLineRequest request = new AttributeLineRequest();
         request.setName("farbe");
         TypeSpec spec = new TypeSpec();
         spec.setDomainFqn("Demo.Core.Farbe");
         request.setTypeSpec(spec);
 
-        AttributeLineV2Response response = attributeTools.createAttributeLineV2(request);
+        AttributeLineResponse response = attributeTools.createAttributeLineV2(request);
 
         assertEquals("farbe : Demo.Core.Farbe;", response.getIliSnippet());
         assertEquals(0, response.getCursorHint().get("line"));
@@ -30,7 +30,7 @@ class AttributeToolsTest {
 
     @Test
     void createAttributeLineV2_formatsBaseTypeRange() {
-        AttributeLineV2Request request = new AttributeLineV2Request();
+        AttributeLineRequest request = new AttributeLineRequest();
         request.setName("hoehe");
         request.setMandatory(true);
         request.setCollection(Collection.LIST_OF);
@@ -45,14 +45,14 @@ class AttributeToolsTest {
         spec.setBaseType(baseType);
         request.setTypeSpec(spec);
 
-        AttributeLineV2Response response = attributeTools.createAttributeLineV2(request);
+        AttributeLineResponse response = attributeTools.createAttributeLineV2(request);
 
         assertEquals("hoehe : MANDATORY LIST OF 0.0 .. 100.0 [INTERLIS.m];", response.getIliSnippet());
     }
 
     @Test
     void createAttributeLineV2_rejectsInvalidAttributeName() {
-        AttributeLineV2Request request = new AttributeLineV2Request();
+        AttributeLineRequest request = new AttributeLineRequest();
         request.setName("1invalid");
         TypeSpec spec = new TypeSpec();
         BaseType baseType = new BaseType();


### PR DESCRIPTION
## Summary
- rename the attribute line request/response DTOs to drop the V2 suffix and update references
- remove the deprecated createAttributeLineLegacy tool and associated test overrides
- remove the deprecated createSnippet alias and its documentation/tests

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541d2531bc8328a052b0174c7384b8)