### PR TITLE
Fix FQN regex literals and add validation coverage

### DIFF
--- a/src/main/java/ch/so/agi/mcp/model/BaseType.java
+++ b/src/main/java/ch/so/agi/mcp/model/BaseType.java
@@ -13,10 +13,10 @@ public class BaseType {
   private Double min;
   private Double max;
 
-  @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
+  @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
   private String unitFqn;
 
-  @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
+  @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
   private String refSysFqn;
 
   private Boolean circular;

--- a/src/main/java/ch/so/agi/mcp/model/TypeSpec.java
+++ b/src/main/java/ch/so/agi/mcp/model/TypeSpec.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Pattern;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TypeSpec {
 
-  @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
+  @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
   private String domainFqn;
   private BaseType baseType;
 

--- a/src/test/java/ch/so/agi/mcp/model/BaseTypeTest.java
+++ b/src/test/java/ch/so/agi/mcp/model/BaseTypeTest.java
@@ -1,10 +1,14 @@
 package ch.so.agi.mcp.model;
 
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class BaseTypeTest {
+
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
 
     @Test
     void validate_allowsTextWithoutLength() {
@@ -87,5 +91,21 @@ class BaseTypeTest {
         BaseType baseType = new BaseType();
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, baseType::validate);
         assertTrue(ex.getMessage().contains("baseType.kind"));
+    }
+
+    @Test
+    void validate_unitFqnAcceptsDotSeparated() {
+        BaseType baseType = new BaseType();
+        baseType.setUnitFqn("Model.Part");
+
+        assertTrue(VALIDATOR.validate(baseType).isEmpty());
+    }
+
+    @Test
+    void validate_unitFqnRejectsBackslashSeparator() {
+        BaseType baseType = new BaseType();
+        baseType.setUnitFqn("Model\\Part");
+
+        assertFalse(VALIDATOR.validate(baseType).isEmpty());
     }
 }

--- a/src/test/java/ch/so/agi/mcp/model/TypeSpecTest.java
+++ b/src/test/java/ch/so/agi/mcp/model/TypeSpecTest.java
@@ -1,0 +1,29 @@
+package ch.so.agi.mcp.model;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TypeSpecTest {
+
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void domainFqn_acceptsDotSeparated() {
+        TypeSpec typeSpec = new TypeSpec();
+        typeSpec.setDomainFqn("Model.Part");
+
+        assertTrue(VALIDATOR.validate(typeSpec).isEmpty());
+    }
+
+    @Test
+    void domainFqn_rejectsBackslashSeparator() {
+        TypeSpec typeSpec = new TypeSpec();
+        typeSpec.setDomainFqn("Model\\Part");
+
+        assertFalse(VALIDATOR.validate(typeSpec).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- update FQN regexes for domain, unit, and reference system values to use literal dots
- add validation tests ensuring dot-separated FQNs are accepted and backslash-separated values are rejected

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542b572c488328a8221c2b606cbac3)