### PR TITLE
Adjust attribute schema optionality

### DIFF
--- a/src/main/java/ch/so/agi/mcp/model/AttributeLineRequest.java
+++ b/src/main/java/ch/so/agi/mcp/model/AttributeLineRequest.java
@@ -1,6 +1,7 @@
 package ch.so.agi.mcp.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Pattern;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -9,9 +10,13 @@ public class AttributeLineRequest {
   public enum Collection { NONE, LIST_OF, BAG_OF }
 
   @Pattern(regexp = "^[A-Za-z][A-Za-z0-9_]*$", message = "Identifier must match ^[A-Za-z][A-Za-z0-9_]*$")
+  @JsonProperty(required = true)
   private String name;
+  @JsonProperty(required = false)
   private Boolean mandatory;
+  @JsonProperty(required = false)
   private Collection collection;
+  @JsonProperty(required = true)
   private TypeSpec typeSpec;
 
   public String getName() { return name; }

--- a/src/main/java/ch/so/agi/mcp/model/BaseType.java
+++ b/src/main/java/ch/so/agi/mcp/model/BaseType.java
@@ -1,6 +1,7 @@
 package ch.so.agi.mcp.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Pattern;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -8,17 +9,24 @@ public class BaseType {
 
   public enum Kind { TEXT, MTEXT, NUMERIC, NUM_RANGE, BOOLEAN, COORD, POLYLINE, SURFACE_SIMPLE }
 
+  @JsonProperty(required = true)
   private Kind kind;
+  @JsonProperty(required = false)
   private Integer length;
+  @JsonProperty(required = false)
   private Double min;
+  @JsonProperty(required = false)
   private Double max;
 
   @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
+  @JsonProperty(required = false)
   private String unitFqn;
 
   @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
+  @JsonProperty(required = false)
   private String refSysFqn;
 
+  @JsonProperty(required = false)
   private Boolean circular;
 
   public Kind getKind() { return kind; }

--- a/src/main/java/ch/so/agi/mcp/model/TypeSpec.java
+++ b/src/main/java/ch/so/agi/mcp/model/TypeSpec.java
@@ -1,13 +1,16 @@
 package ch.so.agi.mcp.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Pattern;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TypeSpec {
 
   @Pattern(regexp = "^([A-Za-z][A-Za-z0-9_]*)(\\.[A-Za-z][A-Za-z0-9_]*)*$", message = "FQN must be dot-separated identifiers")
+  @JsonProperty(required = false)
   private String domainFqn;
+  @JsonProperty(required = false)
   private BaseType baseType;
 
   public String getDomainFqn() { return domainFqn; }


### PR DESCRIPTION
## Summary
- mark BaseType optional fields as non-required while keeping kind required, so tool schema no longer demands every property
- make TypeSpec domain/base fields optional to align with one-of validation rather than both required
- clarify AttributeLineRequest required vs optional flags for generated tool schema

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955996f24148328ae0155e819886913)