### PR TITLE
Add INTERLIS header options to createModelSnippet

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -63,7 +63,7 @@ Ensure `stdin_open` remains true and no TTY is allocated so the MCP JSON-RPC str
 The server registers all tools in `ToolsConfig` and advertises itself as an STDIO, tool-capable MCP endpoint. Each tool returns an object that at least contains `iliSnippet` (the generated INTERLIS fragment) and, where applicable, a `cursorHint` map indicating where to place the caret in editors.
 
 ### Model and topic helpers
-- **`createModelSnippet`** – Generate a model skeleton (`MODEL … END`). Parameters: `name` (required), optional `lang`, `uri`, `version`, and additional `imports`. Defaults fill in `lang="de"`, `version=today`, and `uri=https://example.org/<name>`. Returns `iliSnippet` and a cursor hint pointing to the import section.
+- **`createModelSnippet`** – Generate a model skeleton (`MODEL … END`). Parameters: `name` (required), optional `lang`, `uri`, `version`, `iliVersion` (default `2.4`), `includeSolothurnHeader` (default `false`), and additional `imports`. Defaults fill in `lang="de"`, `version=today`, and `uri=https://example.org/<name>`. Returns `iliSnippet` and a cursor hint pointing to the import section.
 - **`createTopicSnippet`** – Produce a `TOPIC` block. Parameters: `name` (required), optional `oidType` declaration, and `isAbstract` flag. Returns snippet with placeholder comment for classes.
 
 ### Domains and units

--- a/src/e2e/java/ch/so/agi/mcp/StdioE2eTest.java
+++ b/src/e2e/java/ch/so/agi/mcp/StdioE2eTest.java
@@ -112,11 +112,13 @@ public class StdioE2eTest {
         // ---- 3) tools/call createModelSnippet ----
         String today = LocalDate.now().toString();
         String argsJson = "{"
-                + "\"name\":\"DemoModel\","
-                + "\"lang\":\"de\","
-                + "\"uri\":\"https://example.org/DemoModel\","
-                + "\"version\":\"" + today + "\","
-                + "\"imports\":[\"INTERLIS\"]"
+                + "\"name\":\"DemoModel\"," 
+                + "\"lang\":\"de\"," 
+                + "\"uri\":\"https://example.org/DemoModel\"," 
+                + "\"version\":\"" + today + "\"," 
+                + "\"iliVersion\":\"2.4\"," 
+                + "\"imports\":[\"INTERLIS\"]," 
+                + "\"includeSolothurnHeader\":false"
                 + "}";
 
         String createModelCall =
@@ -134,6 +136,8 @@ public class StdioE2eTest {
 
         String createResp = waitForResponseWithId(createModelId, 10_000);
         assertNotNull(createResp, "Did not receive createModelSnippet response");
+        assertTrue(createResp.contains("INTERLIS 2.4"),
+                "createModelSnippet response should contain 'INTERLIS 2.4' but was: " + createResp);
         assertTrue(createResp.contains("MODEL DemoModel (de)"),
                 "createModelSnippet response should contain 'MODEL DemoModel (de)' but was: " + createResp);
     }

--- a/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
@@ -42,12 +42,12 @@ public class ModelTools {
   )
   public Map<String, Object> createModelSnippet(
       @McpToolParam(description = "Modellname (Bezeichner ohne Leerzeichen)", required = true) String name,
-      @McpToolParam(description = "Sprachcode, z. B. 'de' oder 'en'") @Nullable String lang,
-      @McpToolParam(description = "URI des Modells") @Nullable String uri,
-      @McpToolParam(description = "Version im Format YYYY-MM-DD") @Nullable String version,
-      @McpToolParam(description = "INTERLIS Sprachversion (z. B. '2.3' oder '2.4')") @Nullable String iliVersion,
-      @McpToolParam(description = "Zusätzliche Imports (z. B. 'GeometryCHLV95_V1')") @Nullable List<String> imports,
-      @McpToolParam(description = "Fügt einen Solothurn-Header oberhalb des Snippets ein") @Nullable Boolean includeSolothurnHeader
+      @McpToolParam(description = "Sprachcode, z. B. 'de' oder 'en'", required = false) @Nullable String lang,
+      @McpToolParam(description = "URI des Modells", required = false) @Nullable String uri,
+      @McpToolParam(description = "Version im Format YYYY-MM-DD", required = false) @Nullable String version,
+      @McpToolParam(description = "INTERLIS Sprachversion (z. B. '2.3' oder '2.4')", required = false) @Nullable String iliVersion,
+      @McpToolParam(description = "Zusätzliche Imports (z. B. 'GeometryCHLV95_V1')", required = false) @Nullable List<String> imports,
+      @McpToolParam(description = "Fügt einen Solothurn-Header oberhalb des Snippets ein", required = false) @Nullable Boolean includeSolothurnHeader
   ) {
       
       var nv = NameValidator.ascii();

--- a/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
@@ -9,6 +9,8 @@ import ch.so.agi.mcp.util.NameValidator;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,19 +18,36 @@ import java.util.stream.Collectors;
 @Component
 public class ModelTools {
 
+  private static final ZoneId ZURICH = ZoneId.of("Europe/Zurich");
+  private static final String DEFAULT_ILI_VERSION = "2.4";
+  private static final DateTimeFormatter ISO_DAY = DateTimeFormatter.ISO_DATE;
+  private static final String SOLOTHURN_BANNER_TEMPLATE =
+      "/** !!------------------------------------------------------------------------------\n" +
+      " * !! Version    | wer | Änderung\n" +
+      " * !!------------------------------------------------------------------------------\n" +
+      " * !! %s | abr  | Initalversion\n" +
+      " * !!==============================================================================\n" +
+      " */\n" +
+      "!!@ technicalContact=mailto:agi@bd.so.ch\n" +
+      "!!@ title=\"a title\"\n" +
+      "!!@ shortDescription=\"a short description\"\n" +
+      "!!@ tags=\"foo,bar,fubar\"\n";
+
   private final Clock clock;
   public ModelTools(Clock clock) { this.clock = clock; }
 
   @McpTool(
       name = "createModelSnippet",
-      description = "Erzeugt ein INTERLIS-2 Modellgerüst. Params: name (required), lang (default 'de'), version (default 'today'), uri (default 'https://example.org/<name>'), imports (default ['INTERLIS'])."
+      description = "Erzeugt ein INTERLIS-2 Modellgerüst. Params: name (required), lang (default 'de'), version (default 'today'), uri (default 'https://example.org/<name>'), iliVersion (default '2.4'), includeSolothurnHeader (default false), imports (default ['INTERLIS'])."
   )
   public Map<String, Object> createModelSnippet(
       @McpToolParam(description = "Modellname (Bezeichner ohne Leerzeichen)", required = true) String name,
       @McpToolParam(description = "Sprachcode, z. B. 'de' oder 'en'") @Nullable String lang,
       @McpToolParam(description = "URI des Modells") @Nullable String uri,
       @McpToolParam(description = "Version im Format YYYY-MM-DD") @Nullable String version,
-      @McpToolParam(description = "Zusätzliche Imports (z. B. 'GeometryCHLV95_V1')") @Nullable List<String> imports
+      @McpToolParam(description = "INTERLIS Sprachversion (z. B. '2.3' oder '2.4')") @Nullable String iliVersion,
+      @McpToolParam(description = "Zusätzliche Imports (z. B. 'GeometryCHLV95_V1')") @Nullable List<String> imports,
+      @McpToolParam(description = "Fügt einen Solothurn-Header oberhalb des Snippets ein") @Nullable Boolean includeSolothurnHeader
   ) {
       
       var nv = NameValidator.ascii();
@@ -41,20 +60,34 @@ public class ModelTools {
     String _lang = (lang == null || lang.isBlank()) ? "de" : lang.trim();
     String _version = (version == null || version.isBlank()) ? LocalDate.now(clock).toString() : version.trim();
     String _uri = (uri == null || uri.isBlank()) ? ("https://example.org/" + name.toLowerCase()) : uri.trim();
+    String _iliVersion = (iliVersion == null || iliVersion.isBlank()) ? DEFAULT_ILI_VERSION : iliVersion.trim();
+    if (!"2.3".equals(_iliVersion) && !DEFAULT_ILI_VERSION.equals(_iliVersion)) {
+      throw new IllegalArgumentException("iliVersion must be either '2.3' or '2.4'. Got: '" + _iliVersion + "'.");
+    }
     String _imports = (imports == null || imports.isEmpty())
         ? "INTERLIS"
         : imports.stream().map(String::trim).collect(Collectors.joining(", "));
 
-    String snippet = String.format(
-        "MODEL %s (%s) AT \"%s\" VERSION \"%s\" =\n" +
-        "  IMPORTS UNQUALIFIED %s;\n\n" +
-        "END %s.\n",
-        name, _lang, _uri, _version, _imports, name);
+    String header = Boolean.TRUE.equals(includeSolothurnHeader) ? buildSolothurnBanner() : "";
+    int headerLines = header.isEmpty() ? 0 : (int) header.lines().count();
+
+    String snippet = header +
+        String.format(
+            "INTERLIS %s;\n\n" +
+            "MODEL %s (%s) AT \"%s\" VERSION \"%s\" =\n" +
+            "  IMPORTS UNQUALIFIED %s;\n\n" +
+            "END %s.\n",
+            _iliVersion, name, _lang, _uri, _version, _imports, name);
 
     return Map.of(
         "iliSnippet", snippet,
-        "cursorHint", Map.of("line", 2, "col", 0)
+        "cursorHint", Map.of("line", headerLines + 4, "col", 0)
     );
+  }
+
+  private String buildSolothurnBanner() {
+    String today = LocalDate.now(clock.withZone(ZURICH)).format(ISO_DAY);
+    return String.format(SOLOTHURN_BANNER_TEMPLATE, today);
   }
 
 }

--- a/src/main/java/ch/so/agi/mcp/tools/StructureTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/StructureTools.java
@@ -17,9 +17,9 @@ public class StructureTools {
   )
   public Map<String, Object> createStructure(
       @McpToolParam(description = "Strukturname", required = true) String name,
-      @McpToolParam(description = "Abstrakt?") @Nullable Boolean isAbstract,
-      @McpToolParam(description = "EXTENDS (vollqualifiziert)") @Nullable String extendsFqn,
-      @McpToolParam(description = "Attribut-Zeilen (roher ILI-Text)") @Nullable List<String> attrLines
+      @McpToolParam(description = "Abstrakt?", required = false) @Nullable Boolean isAbstract,
+      @McpToolParam(description = "EXTENDS (vollqualifiziert)", required = false) @Nullable String extendsFqn,
+      @McpToolParam(description = "Attribut-Zeilen (roher ILI-Text)", required = false) @Nullable List<String> attrLines
   ) {
     boolean abs = isAbstract != null && isAbstract;
     String header = "STRUCTURE " + name

--- a/src/main/java/ch/so/agi/mcp/tools/TopicTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/TopicTools.java
@@ -16,8 +16,8 @@ public class TopicTools {
         description = "Erzeugt einen TOPIC-Block. Params: name (required), oidType (e.g. 'OID AS UUIDOID'), isAbstract (default false).")
   public Map<String,Object> createTopic(
       @McpToolParam(description = "Topic-Name", required = true) String name,
-      @McpToolParam(description = "OID-Definition, z. B. 'OID AS UUIDOID'") @Nullable String oidType,
-      @McpToolParam(description = "Abstrakter Topic?") @Nullable Boolean isAbstract
+      @McpToolParam(description = "OID-Definition, z. B. 'OID AS UUIDOID'", required = false) @Nullable String oidType,
+      @McpToolParam(description = "Abstrakter Topic?", required = false) @Nullable Boolean isAbstract
   ) {
       var nv = NameValidator.ascii(); 
       nv.validateIdent(name, "Topic name");

--- a/src/main/java/ch/so/agi/mcp/tools/ValidationTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ValidationTools.java
@@ -37,7 +37,7 @@ public class ValidationTools {
   )
   public Map<String, Object> validateIliModel(
       @McpToolParam(description = "INTERLIS-2 Modelltext", required = true) String modelText,
-      @McpToolParam(description = "Optionale MODELREPOS-/ilidirs-Definition, z. B. 'https://models.interlis.ch;https://geo.so.ch/models'")
+      @McpToolParam(description = "Optionale MODELREPOS-/ilidirs-Definition, z. B. 'https://models.interlis.ch;https://geo.so.ch/models'", required = false)
       @Nullable String modelRepositories
   ) {
     if (modelText == null || modelText.isBlank()) {

--- a/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
@@ -36,13 +36,14 @@ class ModelToolsIntegrationTest {
 
     @Test
     void createModelSnippet_usesDefaultsFromSpringContext() {
-        Map<String, Object> result = modelTools.createModelSnippet("TestModel", null, null, null, null);
+        Map<String, Object> result = modelTools.createModelSnippet("TestModel", null, null, null, null, null, null);
 
-        String expectedSnippet = "MODEL TestModel (de) AT \"https://example.org/testmodel\" VERSION \"2024-04-01\" =\n" +
+        String expectedSnippet = "INTERLIS 2.4;\n\n" +
+                "MODEL TestModel (de) AT \"https://example.org/testmodel\" VERSION \"2024-04-01\" =\n" +
                 "  IMPORTS UNQUALIFIED INTERLIS;\n\n" +
                 "END TestModel.\n";
         assertEquals(expectedSnippet, result.get("iliSnippet"));
-        assertEquals(Map.of("line", 2, "col", 0), result.get("cursorHint"));
+        assertEquals(Map.of("line", 4, "col", 0), result.get("cursorHint"));
     }
 
     @Test
@@ -52,10 +53,13 @@ class ModelToolsIntegrationTest {
                 " en ",
                 " https://example.com/demo ",
                 "2023-12-31",
-                List.of("GeometryCHLV95_V1", "Units")
+                "2.3",
+                List.of("GeometryCHLV95_V1", "Units"),
+                null
         );
 
-        String expectedSnippet = "MODEL DemoModel (en) AT \"https://example.com/demo\" VERSION \"2023-12-31\" =\n" +
+        String expectedSnippet = "INTERLIS 2.3;\n\n" +
+                "MODEL DemoModel (en) AT \"https://example.com/demo\" VERSION \"2023-12-31\" =\n" +
                 "  IMPORTS UNQUALIFIED GeometryCHLV95_V1, Units;\n\n" +
                 "END DemoModel.\n";
         assertEquals(expectedSnippet, result.get("iliSnippet"));

--- a/src/test/java/ch/so/agi/mcp/integration/ToolRegistrationContractTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ToolRegistrationContractTest.java
@@ -43,8 +43,12 @@ class ToolRegistrationContractTest {
     assertThat(propertyDescription(properties, "uri")).isEqualTo("URI des Modells");
     assertThat(propertyDescription(properties, "version"))
         .isEqualTo("Version im Format YYYY-MM-DD");
+    assertThat(propertyDescription(properties, "iliVersion"))
+        .isEqualTo("INTERLIS Sprachversion (z. B. '2.3' oder '2.4')");
     assertThat(propertyDescription(properties, "imports"))
         .isEqualTo("Zusätzliche Imports (z. B. 'GeometryCHLV95_V1')");
+    assertThat(propertyDescription(properties, "includeSolothurnHeader"))
+        .isEqualTo("Fügt einen Solothurn-Header oberhalb des Snippets ein");
 
     var request = new McpSchema.CallToolRequest("createModelSnippet", createModelSnippetRequest());
     var response = createModelSnippet.callHandler().apply(null, request);
@@ -52,12 +56,13 @@ class ToolRegistrationContractTest {
 
     assertThat(structured.get("iliSnippet"))
         .isEqualTo(
-            "MODEL TestModel (de) AT \"https://example.org/test\" VERSION \"2024-01-31\" =\n"
+            "INTERLIS 2.3;\n\n"
+                + "MODEL TestModel (de) AT \"https://example.org/test\" VERSION \"2024-01-31\" =\n"
                 + "  IMPORTS UNQUALIFIED INTERLIS, GeometryCHLV95_V1;\n\n"
                 + "END TestModel.\n");
     @SuppressWarnings("unchecked")
     Map<String, Object> cursorHint = (Map<String, Object>) structured.get("cursorHint");
-    assertThat(cursorHint).containsEntry("line", 2).containsEntry("col", 0);
+    assertThat(cursorHint).containsEntry("line", 4).containsEntry("col", 0);
   }
 
   private Map<String, Object> createModelSnippetRequest() {
@@ -66,7 +71,9 @@ class ToolRegistrationContractTest {
         "lang", "de",
         "uri", "https://example.org/test",
         "version", "2024-01-31",
-        "imports", List.of("INTERLIS", "GeometryCHLV95_V1"));
+        "iliVersion", "2.3",
+        "imports", List.of("INTERLIS", "GeometryCHLV95_V1"),
+        "includeSolothurnHeader", false);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- add INTERLIS version declaration and optional Solothurn banner to createModelSnippet output, defaulting to 2.4
- expose iliVersion and includeSolothurnHeader parameters through the MCP tool schema and end-to-end flow
- document the new options and update cursor hints and validations in unit and integration tests

## Testing
- ./gradlew test --no-daemon


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ba154c508328bb5a77280d835852)