### PR TITLE
Add MCP tool to generate coordinate domain snippets

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/DomainTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/DomainTools.java
@@ -5,6 +5,7 @@ import org.springaicommunity.mcp.annotation.McpToolParam;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
+import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,5 +47,64 @@ public class DomainTools {
   ) {
     String snippet = "UNIT\n  " + name + " = " + kind.trim() + " [" + base.trim() + "];";
     return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+  }
+
+  @McpTool(name = "createCoordDomainSnippet",
+        description = "Erzeugt eine COORD-DOMAIN (2D/3D). Params: name (required), dimension (optional, default 2 oder anhand Name=Coord3), decimals (optional, Default 3 = Millimeter).")
+  public Map<String, Object> createCoordDomainSnippet(
+      @McpToolParam(description = "Domain-Name", required = true) String name,
+      @McpToolParam(description = "Koordinatendimension (2 oder 3)") @Nullable Integer dimension,
+      @McpToolParam(description = "Nachkommastellen (Default 3 = Millimeter)") @Nullable Integer decimals
+  ) {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("Domain name is required.");
+    }
+
+    int fractionDigits = decimals == null ? 3 : decimals;
+    if (fractionDigits < 0 || fractionDigits > 9) {
+      throw new IllegalArgumentException("decimals must be between 0 and 9.");
+    }
+
+    String trimmedName = name.trim();
+    int coordDimension = dimension != null ? dimension : (trimmedName.endsWith("3") ? 3 : 2);
+    if (coordDimension != 2 && coordDimension != 3) {
+      throw new IllegalArgumentException("dimension must be 2 or 3.");
+    }
+
+    String snippet = buildCoordDomain(trimmedName, coordDimension, fractionDigits);
+    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+  }
+
+  private String buildCoordDomain(String name, int dimension, int decimals) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("DOMAIN\n  ").append(name).append(" = COORD\n");
+    sb.append("    ")
+        .append(formatValue(460000, decimals))
+        .append(" .. ")
+        .append(formatValue(870000, decimals))
+        .append(" [INTERLIS.m],\n");
+    sb.append("    ")
+        .append(formatValue(45000, decimals))
+        .append(" .. ")
+        .append(formatValue(310000, decimals))
+        .append(" [INTERLIS.m]");
+
+    if (dimension == 3) {
+      sb.append(",\n    ")
+          .append(formatValue(-200, decimals))
+          .append(" .. ")
+          .append(formatValue(5000, decimals))
+          .append(" [INTERLIS.m]\n");
+    } else {
+      sb.append(",\n");
+    }
+
+    sb.append("    ROTATION 2 -> 1;");
+    return sb.toString();
+  }
+
+  private String formatValue(double value, int decimals) {
+    String format = "%." + decimals + "f";
+    return String.format(Locale.ROOT, format, value);
   }
 }

--- a/src/test/java/ch/so/agi/mcp/tools/DomainToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/DomainToolsTest.java
@@ -1,0 +1,50 @@
+package ch.so.agi.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DomainToolsTest {
+
+  private final DomainTools domainTools = new DomainTools();
+
+  @Test
+  void createCoordDomainSnippet_defaultsTo2dAndMillimeter() {
+    Map<String, Object> result = domainTools.createCoordDomainSnippet("Coord2", null, null);
+
+    assertEquals(
+        """
+            DOMAIN
+              Coord2 = COORD
+                460000.000 .. 870000.000 [INTERLIS.m],
+                45000.000 .. 310000.000 [INTERLIS.m],
+                ROTATION 2 -> 1;""",
+        result.get("iliSnippet"));
+    assertEquals(1, ((Map<?, ?>) result.get("cursorHint")).get("line"));
+    assertEquals(2, ((Map<?, ?>) result.get("cursorHint")).get("col"));
+  }
+
+  @Test
+  void createCoordDomainSnippet_infers3dFromNameAndRespectsDecimals() {
+    Map<String, Object> result = domainTools.createCoordDomainSnippet("Coord3", null, 1);
+
+    assertEquals(
+        """
+            DOMAIN
+              Coord3 = COORD
+                460000.0 .. 870000.0 [INTERLIS.m],
+                45000.0 .. 310000.0 [INTERLIS.m],
+                -200.0 .. 5000.0 [INTERLIS.m]
+                ROTATION 2 -> 1;""",
+        result.get("iliSnippet"));
+  }
+
+  @Test
+  void createCoordDomainSnippet_rejectsInvalidDimension() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> domainTools.createCoordDomainSnippet("CoordX", 4, null));
+  }
+}


### PR DESCRIPTION
## Summary
- add new MCP tool `createCoordDomainSnippet` to build 2D/3D coordinate domain snippets with configurable decimals
- include validation for dimension/decimals and formatting utility for coordinate ranges
- add unit tests covering default 2D output, 3D inference from name, and validation errors

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957ec60b9088328b4e6b30b8b931d03)