### PR TITLE
Update model snippet import formatting

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
@@ -38,7 +38,7 @@ public class ModelTools {
 
   @McpTool(
       name = "createModelSnippet",
-      description = "Erzeugt ein INTERLIS-2 Modellgerüst. Params: name (required), lang (default 'de'), version (default 'today'), uri (default 'https://example.org/<name>'), iliVersion (default '2.4'), includeSolothurnHeader (default false), imports (default ['INTERLIS'])."
+      description = "Erzeugt ein INTERLIS-2 Modellgerüst. Params: name (required), lang (default 'de'), version (default 'today'), uri (default 'https://example.org/<name>'), iliVersion (default '2.4'), includeSolothurnHeader (default false), imports (default [])."
   )
   public Map<String, Object> createModelSnippet(
       @McpToolParam(description = "Modellname (Bezeichner ohne Leerzeichen)", required = true) String name,
@@ -50,13 +50,14 @@ public class ModelTools {
       @McpToolParam(description = "Fügt einen Solothurn-Header oberhalb des Snippets ein", required = false) @Nullable Boolean includeSolothurnHeader
   ) {
       
-      var nv = NameValidator.ascii();
-      if (imports != null) {
-        for (String m : imports) {
-          nv.validateIdent(m, "Import model name");
-        }
-      }
-      
+    List<String> trimmedImports = imports == null
+        ? List.of()
+        : imports.stream().map(String::trim).collect(Collectors.toList());
+    var nv = NameValidator.ascii();
+    for (String m : trimmedImports) {
+      nv.validateIdent(m, "Import model name");
+    }
+
     String _lang = (lang == null || lang.isBlank()) ? "de" : lang.trim();
     String _version = (version == null || version.isBlank()) ? LocalDate.now(clock).toString() : version.trim();
     String _uri = (uri == null || uri.isBlank()) ? ("https://example.org/" + name.toLowerCase()) : uri.trim();
@@ -64,24 +65,25 @@ public class ModelTools {
     if (!"2.3".equals(_iliVersion) && !DEFAULT_ILI_VERSION.equals(_iliVersion)) {
       throw new IllegalArgumentException("iliVersion must be either '2.3' or '2.4'. Got: '" + _iliVersion + "'.");
     }
-    String _imports = (imports == null || imports.isEmpty())
-        ? "INTERLIS"
-        : imports.stream().map(String::trim).collect(Collectors.joining(", "));
+    String importLines = trimmedImports.stream()
+        .map(model -> "  IMPORTS " + model + ";\n")
+        .collect(Collectors.joining());
 
     String header = Boolean.TRUE.equals(includeSolothurnHeader) ? buildSolothurnBanner() : "";
     int headerLines = header.isEmpty() ? 0 : (int) header.lines().count();
+    int cursorLine = headerLines + 4 + trimmedImports.size();
 
     String snippet = header +
         String.format(
             "INTERLIS %s;\n\n" +
             "MODEL %s (%s) AT \"%s\" VERSION \"%s\" =\n" +
-            "  IMPORTS UNQUALIFIED %s;\n\n" +
+            "%s\n" +
             "END %s.\n",
-            _iliVersion, name, _lang, _uri, _version, _imports, name);
+            _iliVersion, name, _lang, _uri, _version, importLines, name);
 
     return Map.of(
         "iliSnippet", snippet,
-        "cursorHint", Map.of("line", headerLines + 4, "col", 0)
+        "cursorHint", Map.of("line", cursorLine, "col", 0)
     );
   }
 

--- a/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
@@ -40,7 +40,7 @@ class ModelToolsIntegrationTest {
 
         String expectedSnippet = "INTERLIS 2.4;\n\n" +
                 "MODEL TestModel (de) AT \"https://example.org/testmodel\" VERSION \"2024-04-01\" =\n" +
-                "  IMPORTS UNQUALIFIED INTERLIS;\n\n" +
+                "\n" +
                 "END TestModel.\n";
         assertEquals(expectedSnippet, result.get("iliSnippet"));
         assertEquals(Map.of("line", 4, "col", 0), result.get("cursorHint"));
@@ -60,7 +60,8 @@ class ModelToolsIntegrationTest {
 
         String expectedSnippet = "INTERLIS 2.3;\n\n" +
                 "MODEL DemoModel (en) AT \"https://example.com/demo\" VERSION \"2023-12-31\" =\n" +
-                "  IMPORTS UNQUALIFIED GeometryCHLV95_V1, Units;\n\n" +
+                "  IMPORTS GeometryCHLV95_V1;\n" +
+                "  IMPORTS Units;\n\n" +
                 "END DemoModel.\n";
         assertEquals(expectedSnippet, result.get("iliSnippet"));
     }

--- a/src/test/java/ch/so/agi/mcp/integration/ToolRegistrationContractTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ToolRegistrationContractTest.java
@@ -58,11 +58,12 @@ class ToolRegistrationContractTest {
         .isEqualTo(
             "INTERLIS 2.3;\n\n"
                 + "MODEL TestModel (de) AT \"https://example.org/test\" VERSION \"2024-01-31\" =\n"
-                + "  IMPORTS UNQUALIFIED INTERLIS, GeometryCHLV95_V1;\n\n"
+                + "  IMPORTS INTERLIS;\n"
+                + "  IMPORTS GeometryCHLV95_V1;\n\n"
                 + "END TestModel.\n");
     @SuppressWarnings("unchecked")
     Map<String, Object> cursorHint = (Map<String, Object>) structured.get("cursorHint");
-    assertThat(cursorHint).containsEntry("line", 4).containsEntry("col", 0);
+    assertThat(cursorHint).containsEntry("line", 6).containsEntry("col", 0);
   }
 
   private Map<String, Object> createModelSnippetRequest() {

--- a/src/test/java/ch/so/agi/mcp/tools/ModelToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ModelToolsTest.java
@@ -32,7 +32,7 @@ class ModelToolsTest {
 
         String expectedSnippet = "INTERLIS 2.4;\n\n"
                 + "MODEL TestModel (de) AT \"https://example.org/testmodel\" VERSION \"2024-05-01\" =\n"
-                + "  IMPORTS UNQUALIFIED INTERLIS;\n\n"
+                + "\n"
                 + "END TestModel.\n";
 
         assertEquals(expectedSnippet, result.get("iliSnippet"));
@@ -57,14 +57,15 @@ class ModelToolsTest {
 
         String expectedSnippet = "INTERLIS 2.3;\n\n"
                 + "MODEL TrimModel (en) AT \"https://data.example/TrimModel\" VERSION \"2024-01-31\" =\n"
-                + "  IMPORTS UNQUALIFIED INTERLIS, GeometryCHLV95_V1;\n\n"
+                + "  IMPORTS INTERLIS;\n"
+                + "  IMPORTS GeometryCHLV95_V1;\n\n"
                 + "END TrimModel.\n";
 
         assertEquals(expectedSnippet, result.get("iliSnippet"));
 
         @SuppressWarnings("unchecked")
         Map<String, Integer> cursorHint = (Map<String, Integer>) result.get("cursorHint");
-        assertEquals(Map.of("line", 4, "col", 0), cursorHint);
+        assertEquals(Map.of("line", 6, "col", 0), cursorHint);
     }
 
     @Test
@@ -115,7 +116,6 @@ class ModelToolsTest {
                 INTERLIS 2.4;
 
                 MODEL HeaderModel (de) AT "https://example.org/headermodel" VERSION "2024-05-01" =
-                  IMPORTS UNQUALIFIED INTERLIS;
 
                 END HeaderModel.
                 """.stripIndent();


### PR DESCRIPTION
### Motivation
- Stop implicitly adding a default `INTERLIS` import in the generated model snippet so imports must be explicit.
- Emit imports as non-`UNQUALIFIED` and produce one `IMPORTS` line per model to match desired formatting.
- Ensure provided import identifiers are trimmed and validated before being used in the snippet.
- Adjust the returned cursor hint to account for a variable number of import lines.

### Description
- Change `createModelSnippet` to treat the `imports` parameter default as empty, trim values, and validate identifiers via `NameValidator`.
- Build per-model import lines (`"  IMPORTS <ModelName>;\n"`) instead of a single `IMPORTS UNQUALIFIED ...` line and remove the `UNQUALIFIED` qualifier.
- Recompute the cursor line as `headerLines + 4 + trimmedImports.size()` so the cursor is placed after import lines.
- Update unit and integration expectations in `ModelToolsTest`, `ModelToolsIntegrationTest`, and `ToolRegistrationContractTest` to reflect the new import layout and cursor positions.

### Testing
- No automated tests were executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd1fe280c8328a210cbd94a41418e)