### PR TITLE
Return full `IMPORTS` lines from ensureGeometryDependencies and update tests

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/GeometryAttributeTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/GeometryAttributeTools.java
@@ -102,8 +102,13 @@ public class GeometryAttributeTools {
       attributeLine = buildGeometryAttribute(attributePrefix, geom, coordDomainName, useArcs, overlapMeters, isDirected);
     }
 
+    List<String> importLines = new ArrayList<>();
+    for (String model : imports) {
+      importLines.add("IMPORTS " + model + ";");
+    }
+
     return Map.of(
-        "importsToAdd", imports,
+        "importLinesToAdd", importLines,
         "domainsToAdd", domains,
         "attributeLine", attributeLine,
         "notes", notes

--- a/src/test/java/ch/so/agi/mcp/tools/GeometryAttributeToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/GeometryAttributeToolsTest.java
@@ -17,8 +17,8 @@ class GeometryAttributeToolsTest {
         "attr2", 2, true, new BigDecimal("2"), false, "2.4", "SURFACE", false, null, null);
 
     assertEquals("attr2 : SURFACE WITH (STRAIGHTS, ARCS)\n        VERTEX Coord2\n        WITHOUT OVERLAPS > 0.002;", result.get("attributeLine"));
-    assertEquals(1, ((java.util.List<?>) result.get("importsToAdd")).size());
-    assertTrue(((java.util.List<?>) result.get("importsToAdd")).contains("INTERLIS"));
+    assertEquals(1, ((java.util.List<?>) result.get("importLinesToAdd")).size());
+    assertTrue(((java.util.List<?>) result.get("importLinesToAdd")).contains("IMPORTS INTERLIS;"));
     assertEquals(1, ((java.util.List<?>) result.get("domainsToAdd")).size());
     assertEquals(2, ((java.util.List<?>) result.get("notes")).size());
   }
@@ -29,7 +29,7 @@ class GeometryAttributeToolsTest {
         "geom", 2, false, null, true, "2.4", "SURFACE", false, null, null);
 
     assertEquals("geom : GeometryCHLV95_V2.MultiSurfaceWithoutArcs;", result.get("attributeLine"));
-    assertTrue(((java.util.List<?>) result.get("importsToAdd")).contains("GeometryCHLV95_V2"));
+    assertTrue(((java.util.List<?>) result.get("importLinesToAdd")).contains("IMPORTS GeometryCHLV95_V2;"));
     assertTrue(((java.util.List<?>) result.get("domainsToAdd")).isEmpty());
   }
 


### PR DESCRIPTION
### Motivation

- Ensure the tool emits complete `IMPORTS <Model>;` statements instead of bare model names for clarity in generated INTERLIS snippets.
- Produce one import statement per model on its own line to match expected output formatting.
- Expose the new output field as `importLinesToAdd` to clearly indicate these are complete lines to insert.
- Update tests to reflect the new output shape and contents.

### Description

- Changed `ensureGeometryDependencies` to build `importLines` containing strings like `IMPORTS GeometryCHLV95_V2;` and return them under the `importLinesToAdd` key instead of `importsToAdd`.
- Kept existing `domainsToAdd`, `attributeLine`, and `notes` return values intact.
- Updated unit tests in `GeometryAttributeToolsTest` to assert against `importLinesToAdd` and to check for the full `IMPORTS ...;` strings.
- Modified `src/main/java/ch/so/agi/mcp/tools/GeometryAttributeTools.java` and `src/test/java/ch/so/agi/mcp/tools/GeometryAttributeToolsTest.java` accordingly.

### Testing

- Unit tests were updated to match the new output field and values but were not executed in this rollout.
- No automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd3c16864832896718cedaf3c2343)