### PR TITLE
Add MathTools and unit tests for INTERLIS math function listing

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/MathTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/MathTools.java
@@ -1,0 +1,88 @@
+package ch.so.agi.mcp.tools;
+
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class MathTools {
+
+  private static final List<String> MATH_FUNCTIONS_23 = List.of(
+      "add(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "sub(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "mul(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "div(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "abs(a: NUMERIC): NUMERIC",
+      "acos(a: NUMERIC): NUMERIC",
+      "asin(a: NUMERIC): NUMERIC",
+      "atan(a: NUMERIC): NUMERIC",
+      "atan2(ordinate: NUMERIC; abscissa: NUMERIC): NUMERIC",
+      "cbrt(a: NUMERIC): NUMERIC",
+      "cos(a: NUMERIC): NUMERIC",
+      "cosh(a: NUMERIC): NUMERIC",
+      "exp(a: NUMERIC): NUMERIC",
+      "hypot(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "log(a: NUMERIC): NUMERIC",
+      "log10(a: NUMERIC): NUMERIC",
+      "pow(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "round(a: NUMERIC): NUMERIC",
+      "signum(a: NUMERIC): NUMERIC",
+      "sin(a: NUMERIC): NUMERIC",
+      "sinh(a: NUMERIC): NUMERIC",
+      "sqrt(a: NUMERIC): NUMERIC",
+      "tan(a: NUMERIC): NUMERIC",
+      "tanh(a: NUMERIC): NUMERIC",
+      "max(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "min(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "avg(attributePath: TEXT): NUMERIC",
+      "max2(attributePath: TEXT): NUMERIC",
+      "min2(attributePath: TEXT): NUMERIC",
+      "sum(attributePath: TEXT): NUMERIC"
+  );
+
+  private static final List<String> MATH_FUNCTIONS_24 = List.of(
+      "add(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "sub(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "mul(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "div(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "abs(a: NUMERIC): NUMERIC",
+      "acos(a: NUMERIC): NUMERIC",
+      "asin(a: NUMERIC): NUMERIC",
+      "atan(a: NUMERIC): NUMERIC",
+      "atan2(ordinate: NUMERIC; abscissa: NUMERIC): NUMERIC",
+      "cbrt(a: NUMERIC): NUMERIC",
+      "cos(a: NUMERIC): NUMERIC",
+      "cosh(a: NUMERIC): NUMERIC",
+      "exp(a: NUMERIC): NUMERIC",
+      "hypot(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "log(a: NUMERIC): NUMERIC",
+      "log10(a: NUMERIC): NUMERIC",
+      "pow(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "round(a: NUMERIC): NUMERIC",
+      "signum(a: NUMERIC): NUMERIC",
+      "sin(a: NUMERIC): NUMERIC",
+      "sinh(a: NUMERIC): NUMERIC",
+      "sqrt(a: NUMERIC): NUMERIC",
+      "tan(a: NUMERIC): NUMERIC",
+      "tanh(a: NUMERIC): NUMERIC",
+      "max(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "min(a: NUMERIC; b: NUMERIC): NUMERIC",
+      "avg(attributePath: TEXT): NUMERIC",
+      "max2(attributePath: TEXT): NUMERIC",
+      "min2(attributePath: TEXT): NUMERIC",
+      "sum(attributePath: TEXT): NUMERIC"
+  );
+
+  @McpTool(
+      name = "listMathFunctions",
+      description = "Listet alle INTERLIS-Math-Funktionen für 2.3 und 2.4 mit Signatur und Rückgabetyp auf."
+  )
+  public Map<String, Object> listMathFunctions() {
+    return Map.of(
+        "2.3", MATH_FUNCTIONS_23,
+        "2.4", MATH_FUNCTIONS_24
+    );
+  }
+}

--- a/src/test/java/ch/so/agi/mcp/tools/MathToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/MathToolsTest.java
@@ -1,0 +1,32 @@
+package ch.so.agi.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MathToolsTest {
+
+  private final MathTools mathTools = new MathTools();
+
+  @Test
+  void listMathFunctions_returnsFunctionsForBothVersions() {
+    Map<String, Object> result = mathTools.listMathFunctions();
+
+    assertTrue(result.containsKey("2.3"));
+    assertTrue(result.containsKey("2.4"));
+
+    @SuppressWarnings("unchecked")
+    List<String> v23 = (List<String>) result.get("2.3");
+    @SuppressWarnings("unchecked")
+    List<String> v24 = (List<String>) result.get("2.4");
+
+    assertEquals(30, v23.size());
+    assertEquals(30, v24.size());
+    assertTrue(v23.contains("atan2(ordinate: NUMERIC; abscissa: NUMERIC): NUMERIC"));
+    assertTrue(v24.contains("avg(attributePath: TEXT): NUMERIC"));
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an MCP tool that lists INTERLIS math functions (with signatures and return types) for versions `2.3` and `2.4`.
- The previously added tool lacked automated tests and the change aimed to make the function listings verifiable.
- Ensure clients/tools can reliably retrieve the function lists for both INTERLIS versions.

### Description

- Added `MathTools` component with an `@McpTool`-annotated method `listMathFunctions()` that returns a `Map` keyed by `"2.3"` and `"2.4"` containing the function signatures.
- Introduced constant lists `MATH_FUNCTIONS_23` and `MATH_FUNCTIONS_24` containing the INTERLIS function signatures used by `listMathFunctions()`.
- Added unit test `MathToolsTest` in `src/test/java/ch/so/agi/mcp/tools` that instantiates `MathTools` and asserts the presence of keys, expected list sizes, and example signatures such as `atan2(ordinate: NUMERIC; abscissa: NUMERIC): NUMERIC` and `avg(attributePath: TEXT): NUMERIC`.

### Testing

- Executed `./gradlew test` to run the test suite.
- All tests completed successfully and the build reported `BUILD SUCCESSFUL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe0b449ac8328b0731ec4e5965126)