### PR TITLE
Qualify CHBase geometry type names in listGeometryTypes

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/GeometryAttributeTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/GeometryAttributeTools.java
@@ -123,13 +123,14 @@ public class GeometryAttributeTools {
       @McpToolParam(description = "INTERLIS Sprachversion (2.3 oder 2.4)", required = false) @Nullable String iliVersion
   ) {
     String ili = normalizeIliVersion(iliVersion);
+    String modelName = "2.3".equals(ili) ? "GeometryCHLV95_V1" : "GeometryCHLV95_V2";
     List<Map<String, String>> entries = new ArrayList<>();
     interlisGeometryTypes(ili).forEach(type -> entries.add(Map.of(
         "name", type,
         "model", "INTERLIS"
     )));
     chBaseGeometryTypes(ili).forEach(type -> entries.add(Map.of(
-        "name", type,
+        "name", modelName + "." + type,
         "model", "CHBase"
     )));
     return Map.of(


### PR DESCRIPTION
### Motivation
- Ensure CHBase geometry types returned by `listGeometryTypes` are fully qualified with their CHBase model name.
- The CHBase model differs between INTERLIS versions, so the model name must be chosen based on the `iliVersion` (`2.3` vs `2.4`).
- INTERLIS geometry type entries should remain unchanged and unqualified.

### Description
- Determine `modelName` inside `listGeometryTypes` using the normalized `ili` (`"GeometryCHLV95_V1"` for `2.3`, `"GeometryCHLV95_V2"` for `2.4`).
- Prefix CHBase type names with `modelName + "." + type` when building the `types` list from `chBaseGeometryTypes(ili)`.
- Leave INTERLIS entries intact and do not modify other geometry selection or domain logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fb6fc0988328ad8c2ce33648c3e9)