### PR TITLE
Simplify CHBase geometry inputs and use Coord2/Coord3

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 # interlis-mcp
 
 
+- siehe Blog mcp pattern wegen ...
+
 ## todo
 - diff vs komplett vs. inline -> siehe chatgpt
 - Wie unterbindet man, dass er "NUMERIC" als Attributtyp mitschickt? Wie kann man die Attributtypen grundsätzlich robuster gestalten?

--- a/src/main/java/ch/so/agi/mcp/tools/ClassTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ClassTools.java
@@ -19,8 +19,8 @@ public class ClassTools {
       @McpToolParam(description = "Klassenname", required = true) String name,
       @McpToolParam(description = "Abstrakt?", required = false) @Nullable Boolean isAbstract,
       @McpToolParam(description = "EXTENDS (vollqualifiziert)", required = false) @Nullable String extendsFqn,
-      @McpToolParam(description = "OID-Definition, z. B. 'OID AS UUIDOID'", required = true) @Nullable String oidDecl,
-      @McpToolParam(description = "Attribut-Zeilen (roher ILI-Text)", required = true) @Nullable List<String> attrLines
+      @McpToolParam(description = "OID-Definition, z. B. 'OID AS INTERLIS.UUIDOID'", required = false) @Nullable String oidDecl,
+      @McpToolParam(description = "Attribut-Zeilen (roher ILI-Text)", required = false) @Nullable List<String> attrLines
   ) {
       var nv = NameValidator.ascii(); 
       nv.validateIdent(name, "Class name");

--- a/src/main/java/ch/so/agi/mcp/tools/TopicTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/TopicTools.java
@@ -13,10 +13,10 @@ import java.util.Map;
 public class TopicTools {
 
   @McpTool(name = "createTopicSnippet",
-        description = "Erzeugt einen TOPIC-Block. Params: name (required), oidType (e.g. 'OID AS UUIDOID'), isAbstract (default false).")
+        description = "Erzeugt einen TOPIC-Block. Params: name (required), oidType (e.g. 'OID AS INTERLIS.UUIDOID'), isAbstract (default false).")
   public Map<String,Object> createTopic(
       @McpToolParam(description = "Topic-Name", required = true) String name,
-      @McpToolParam(description = "OID-Definition, z. B. 'OID AS UUIDOID'", required = false) @Nullable String oidType,
+      @McpToolParam(description = "OID-Definition, z. B. 'OID AS INTERLIS.UUIDOID'", required = false) @Nullable String oidType,
       @McpToolParam(description = "Abstrakter Topic?", required = false) @Nullable Boolean isAbstract
   ) {
       var nv = NameValidator.ascii(); 

--- a/src/test/java/ch/so/agi/mcp/tools/GeometryAttributeToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/GeometryAttributeToolsTest.java
@@ -26,7 +26,7 @@ class GeometryAttributeToolsTest {
   @Test
   void ensureGeometryDependencies_usesChbaseModels() {
     Map<String, Object> result = geometryAttributeTools.ensureGeometryDependencies(
-        "geom", 2, false, null, true, "2.4", "SURFACE", false, null, null);
+        "geom", 2, false, null, true, "2.4", "GeometryCHLV95_V2.MultiSurfaceWithoutArcs", false, null, null);
 
     assertEquals("geom : GeometryCHLV95_V2.MultiSurfaceWithoutArcs;", result.get("attributeLine"));
     assertTrue(((java.util.List<?>) result.get("importLinesToAdd")).contains("IMPORTS GeometryCHLV95_V2;"));
@@ -44,7 +44,7 @@ class GeometryAttributeToolsTest {
   @Test
   void ensureGeometryDependencies_supportsChbaseCoord() {
     Map<String, Object> result = geometryAttributeTools.ensureGeometryDependencies(
-        "pos", 3, false, null, true, "2.4", "COORD", false, null, null);
+        "pos", 3, false, null, true, "2.4", "GeometryCHLV95_V2.Coord3", false, null, null);
 
     assertEquals("pos : GeometryCHLV95_V2.Coord3;", result.get("attributeLine"));
     assertTrue(((java.util.List<?>) result.get("domainsToAdd")).isEmpty());


### PR DESCRIPTION
### Motivation
- Allow callers (agents/LLMs) to pass the correct geometry type name (including qualified CHBase names) to `ensureGeometryDependencies` without extra normalization.
- Let callers use `listGeometryTypes` to discover available types and avoid duplicating selection logic in the tool.
- Reflect the CH-Base reality that there is no generic `Coord` type and only `Coord2`/`Coord3` are available.
- Remove redundant and brittle mapping/selection code that attempted to canonicalize CHBase geometry names.

### Description
- Accept `geometryType` as provided for CHBase and qualify unqualified names with the model using `qualifyChBaseGeometry`, and explicitly reject an unqualified `Coord` request.
- Remove the previous normalization/validation and the large `buildChBaseGeometry`/selection logic and simplify `chBase24` mappings to expose `Coord2` and `Coord3`.
- Adjust `isLineGeometry` to extract the base type when a CHBase qualified name (model-prefixed) is used.
- Update unit tests to pass qualified CHBase type names (e.g. `GeometryCHLV95_V2.MultiSurfaceWithoutArcs`, `GeometryCHLV95_V2.Coord3`).

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610168a9d883288ac8c5b8858f1ff4)