### PR TITLE
Remove cursorHint from MCP tool responses

### DIFF
--- a/src/main/java/ch/so/agi/mcp/model/AttributeLineResponse.java
+++ b/src/main/java/ch/so/agi/mcp/model/AttributeLineResponse.java
@@ -1,21 +1,14 @@
 package ch.so.agi.mcp.model;
 
-import java.util.Map;
-
 public class AttributeLineResponse {
   private String iliSnippet;
-  private Map<String,Integer> cursorHint;
 
   public AttributeLineResponse() {}
 
   public AttributeLineResponse(String iliSnippet) {
     this.iliSnippet = iliSnippet;
-    this.cursorHint = Map.of("line", 0, "col", 0);
   }
 
   public String getIliSnippet() { return iliSnippet; }
   public void setIliSnippet(String iliSnippet) { this.iliSnippet = iliSnippet; }
-
-  public Map<String,Integer> getCursorHint() { return cursorHint; }
-  public void setCursorHint(Map<String,Integer> cursorHint) { this.cursorHint = cursorHint; }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/AssociationTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/AssociationTools.java
@@ -36,6 +36,6 @@ public class AssociationTools {
       sb.append("  ").append(r.name).append(" -- ").append(r.card).append(" ").append(r.classFQN).append(";\n");
     }
     sb.append("END ").append(name).append(";");
-    return Map.of("iliSnippet", sb.toString(), "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", sb.toString());
   }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/ClassTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ClassTools.java
@@ -44,7 +44,7 @@ public class ClassTools {
       sb.append("  !! Attribute hier\n");
     }
     sb.append("END ").append(name).append(";");
-    return Map.of("iliSnippet", sb.toString(), "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", sb.toString());
   }
 
 //  @Tool(name = "createAttributeLine",
@@ -63,6 +63,6 @@ public class ClassTools {
 //    String base = (domainFqn != null && !domainFqn.isBlank()) ? domainFqn.trim() : type.trim();
 //    String mand = (mandatory != null && mandatory) ? "MANDATORY " : "";
 //    String line = name + " : " + mand + col + base + ";";
-//    return Map.of("iliSnippet", line, "cursorHint", Map.of("line", 0, "col", 0));
+//    return Map.of("iliSnippet", line);
 //  }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/ConstraintTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ConstraintTools.java
@@ -18,7 +18,7 @@ public class ConstraintTools {
   ) {
     String inner = attrs.stream().map(String::trim).collect(Collectors.joining(", "));
     String snippet = "CONSTRAINTS\n  UNIQUE (" + inner + ");";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createMandatoryConstraint",
@@ -27,7 +27,7 @@ public class ConstraintTools {
       @McpToolParam(description = "boolescher Ausdruck", required = true) String expr
   ) {
     String snippet = "CONSTRAINTS\n  MANDATORY CONSTRAINT " + expr.trim() + ";";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createSetConstraint",
@@ -36,7 +36,7 @@ public class ConstraintTools {
       @McpToolParam(description = "Mengen-Ausdruck", required = true) String expr
   ) {
     String snippet = "CONSTRAINTS\n  SET CONSTRAINT\n    " + expr.trim() + ";";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 2, "col", 4));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createPresentIfConstraint",
@@ -46,7 +46,7 @@ public class ConstraintTools {
       @McpToolParam(description = "Bedingung", required = true) String cond
   ) {
     String snippet = "CONSTRAINTS\n  PRESENT " + attr.trim() + " IF " + cond.trim() + ";";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createValueRangeConstraint",
@@ -56,7 +56,7 @@ public class ConstraintTools {
       @McpToolParam(description = "Range, z. B. '0.0 .. 4000.0'", required = true) String range
   ) {
     String snippet = "CONSTRAINTS\n  VALUE " + attr.trim() + " IN " + range.trim() + ";";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createExistenceConstraint",
@@ -67,6 +67,6 @@ public class ConstraintTools {
   ) {
     String inner = classFqns.stream().map(String::trim).collect(Collectors.joining(", "));
     String snippet = "CONSTRAINTS\n  EXISTENCE CONSTRAINT " + refAttr.trim() + " REQUIRED IN " + inner + ";";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/DomainTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/DomainTools.java
@@ -21,7 +21,7 @@ public class DomainTools {
   ) {
     String inner = items.stream().map(String::trim).collect(Collectors.joining(", "));
     String snippet = "DOMAIN\n  " + name + " = (" + inner + ");";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createNumericDomainSnippet",
@@ -35,7 +35,7 @@ public class DomainTools {
     String range = min.trim() + " .. " + max.trim();
     String unit = (unitFqn != null && !unitFqn.isBlank()) ? " [" + unitFqn.trim() + "]" : "";
     String snippet = "DOMAIN\n  " + name + " = " + range + unit + ";";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createUnitSnippet",
@@ -46,7 +46,7 @@ public class DomainTools {
       @McpToolParam(description = "Basis-Einheit, z. B. INTERLIS.m", required = true) String base
   ) {
     String snippet = "UNIT\n  " + name + " = " + kind.trim() + " [" + base.trim() + "];";
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   @McpTool(name = "createCoordDomainSnippet",
@@ -72,7 +72,7 @@ public class DomainTools {
     }
 
     String snippet = buildCoordDomain(trimmedName, coordDimension, fractionDigits);
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 
   private String buildCoordDomain(String name, int dimension, int decimals) {

--- a/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/ModelTools.java
@@ -82,8 +82,7 @@ public class ModelTools {
             _iliVersion, name, _lang, _uri, _version, importLines, name);
 
     return Map.of(
-        "iliSnippet", snippet,
-        "cursorHint", Map.of("line", cursorLine, "col", 0)
+        "iliSnippet", snippet
     );
   }
 

--- a/src/main/java/ch/so/agi/mcp/tools/StructureAttributeTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/StructureAttributeTools.java
@@ -50,8 +50,7 @@ public class StructureAttributeTools {
 
     String line = name.trim() + " : " + prefix + colPrefix + structureFqn.trim() + ";";
     return Map.of(
-        "iliSnippet", line,
-        "cursorHint", Map.of("line", 0, "col", 0)
+        "iliSnippet", line
     );
   }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/StructureTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/StructureTools.java
@@ -39,6 +39,6 @@ public class StructureTools {
     }
 
     sb.append("END ").append(name).append(";");
-    return Map.of("iliSnippet", sb.toString(), "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", sb.toString());
   }
 }

--- a/src/main/java/ch/so/agi/mcp/tools/TopicTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/TopicTools.java
@@ -27,6 +27,6 @@ public class TopicTools {
     String oid = (oidType != null && !oidType.isBlank()) ? "  " + oidType.trim() + ";\n" : "";
     String snippet = header + "\n" + oid + "  !! Klassen/Assoziationen hier\nEND " + name + ";";
 
-    return Map.of("iliSnippet", snippet, "cursorHint", Map.of("line", 1, "col", 2));
+    return Map.of("iliSnippet", snippet);
   }
 }

--- a/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ModelToolsIntegrationTest.java
@@ -43,7 +43,6 @@ class ModelToolsIntegrationTest {
                 "\n" +
                 "END TestModel.\n";
         assertEquals(expectedSnippet, result.get("iliSnippet"));
-        assertEquals(Map.of("line", 4, "col", 0), result.get("cursorHint"));
     }
 
     @Test

--- a/src/test/java/ch/so/agi/mcp/integration/ToolRegistrationContractTest.java
+++ b/src/test/java/ch/so/agi/mcp/integration/ToolRegistrationContractTest.java
@@ -61,9 +61,6 @@ class ToolRegistrationContractTest {
                 + "  IMPORTS INTERLIS;\n"
                 + "  IMPORTS GeometryCHLV95_V1;\n\n"
                 + "END TestModel.\n");
-    @SuppressWarnings("unchecked")
-    Map<String, Object> cursorHint = (Map<String, Object>) structured.get("cursorHint");
-    assertThat(cursorHint).containsEntry("line", 6).containsEntry("col", 0);
   }
 
   private Map<String, Object> createModelSnippetRequest() {

--- a/src/test/java/ch/so/agi/mcp/tools/AssociationToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/AssociationToolsTest.java
@@ -32,7 +32,6 @@ class AssociationToolsTest {
                 "  to -- {0..*} Mod.Topic.Target;",
                 "END Link;"
         ), response.get("iliSnippet"));
-        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
     }
 
     @Test
@@ -54,4 +53,3 @@ class AssociationToolsTest {
         assertTrue(ex.getMessage().contains("Association role name"));
     }
 }
-

--- a/src/test/java/ch/so/agi/mcp/tools/AttributeToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/AttributeToolsTest.java
@@ -24,8 +24,6 @@ class AttributeToolsTest {
         AttributeLineResponse response = attributeTools.createAttributeLine(request);
 
         assertEquals("farbe : Demo.Core.Farbe;", response.getIliSnippet());
-        assertEquals(0, response.getCursorHint().get("line"));
-        assertEquals(0, response.getCursorHint().get("col"));
     }
 
     @Test

--- a/src/test/java/ch/so/agi/mcp/tools/ClassToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ClassToolsTest.java
@@ -29,7 +29,6 @@ class ClassToolsTest {
                 "END Baum;"
         );
         assertEquals(expected, response.get("iliSnippet"));
-        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
     }
 
     @Test
@@ -58,4 +57,3 @@ class ClassToolsTest {
         assertTrue(ex.getMessage().contains("EXTENDS FQN"));
     }
 }
-

--- a/src/test/java/ch/so/agi/mcp/tools/ConstraintToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ConstraintToolsTest.java
@@ -19,7 +19,6 @@ class ConstraintToolsTest {
                 "CONSTRAINTS",
                 "  UNIQUE (name, lage);"
         ), response.get("iliSnippet"));
-        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
     }
 
     @Test
@@ -31,7 +30,6 @@ class ConstraintToolsTest {
                 "  SET CONSTRAINT",
                 "    AREA->STANDORT->count() > 0;"
         ), response.get("iliSnippet"));
-        assertEquals(Map.of("line", 2, "col", 4), response.get("cursorHint"));
     }
 
     @Test
@@ -44,4 +42,3 @@ class ConstraintToolsTest {
         ), response.get("iliSnippet"));
     }
 }
-

--- a/src/test/java/ch/so/agi/mcp/tools/DomainToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/DomainToolsTest.java
@@ -22,8 +22,6 @@ class DomainToolsTest {
                 45000.000 .. 310000.000 [INTERLIS.m],
                 ROTATION 2 -> 1;""",
         result.get("iliSnippet"));
-    assertEquals(1, ((Map<?, ?>) result.get("cursorHint")).get("line"));
-    assertEquals(2, ((Map<?, ?>) result.get("cursorHint")).get("col"));
   }
 
   @Test

--- a/src/test/java/ch/so/agi/mcp/tools/ModelToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ModelToolsTest.java
@@ -110,7 +110,7 @@ class ModelToolsTest {
                 MODEL HeaderModel (de) AT "https://example.org/headermodel" VERSION "2024-05-01" =
 
                 END HeaderModel.
-        """.stripIndent();
+                """.stripIndent();
 
         assertEquals(expectedSnippet, result.get("iliSnippet"));
     }

--- a/src/test/java/ch/so/agi/mcp/tools/ModelToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/ModelToolsTest.java
@@ -36,10 +36,6 @@ class ModelToolsTest {
                 + "END TestModel.\n";
 
         assertEquals(expectedSnippet, result.get("iliSnippet"));
-
-        @SuppressWarnings("unchecked")
-        Map<String, Integer> cursorHint = (Map<String, Integer>) result.get("cursorHint");
-        assertEquals(Map.of("line", 4, "col", 0), cursorHint);
     }
 
     @Test
@@ -62,10 +58,6 @@ class ModelToolsTest {
                 + "END TrimModel.\n";
 
         assertEquals(expectedSnippet, result.get("iliSnippet"));
-
-        @SuppressWarnings("unchecked")
-        Map<String, Integer> cursorHint = (Map<String, Integer>) result.get("cursorHint");
-        assertEquals(Map.of("line", 6, "col", 0), cursorHint);
     }
 
     @Test
@@ -90,7 +82,7 @@ class ModelToolsTest {
     }
 
     @Test
-    @DisplayName("createModelSnippet builds Solothurn header with Zurich date and updates cursor hint")
+    @DisplayName("createModelSnippet builds Solothurn header with Zurich date")
     void createModelSnippetAddsSolothurnHeader() {
         Map<String, Object> result = modelTools.createModelSnippet(
                 "HeaderModel",
@@ -118,13 +110,9 @@ class ModelToolsTest {
                 MODEL HeaderModel (de) AT "https://example.org/headermodel" VERSION "2024-05-01" =
 
                 END HeaderModel.
-                """.stripIndent();
+        """.stripIndent();
 
         assertEquals(expectedSnippet, result.get("iliSnippet"));
-
-        @SuppressWarnings("unchecked")
-        Map<String, Integer> cursorHint = (Map<String, Integer>) result.get("cursorHint");
-        assertEquals(Map.of("line", 14, "col", 0), cursorHint);
     }
 
     @Test

--- a/src/test/java/ch/so/agi/mcp/tools/StructureToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/StructureToolsTest.java
@@ -25,7 +25,6 @@ class StructureToolsTest {
                 "  plz : 4 .. 5;",
                 "END Adresse;"
         ), response.get("iliSnippet"));
-        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
     }
 
     @Test
@@ -39,4 +38,3 @@ class StructureToolsTest {
         ), response.get("iliSnippet"));
     }
 }
-

--- a/src/test/java/ch/so/agi/mcp/tools/TopicToolsTest.java
+++ b/src/test/java/ch/so/agi/mcp/tools/TopicToolsTest.java
@@ -20,7 +20,6 @@ class TopicToolsTest {
                 "  !! Klassen/Assoziationen hier",
                 "END Geo;"
         ), response.get("iliSnippet"));
-        assertEquals(Map.of("line", 1, "col", 2), response.get("cursorHint"));
     }
 
     @Test
@@ -30,4 +29,3 @@ class TopicToolsTest {
         assertTrue(response.get("iliSnippet").toString().startsWith("TOPIC Verkehr (ABSTRACT) ="));
     }
 }
-


### PR DESCRIPTION
### Motivation

- Simplify tool response payloads by removing the `cursorHint` field from all MCP tool outputs and the related response model to keep the API shape focused on the generated `iliSnippet`.
- Align unit and integration tests with the new response shape so they no longer depend on `cursorHint` values.

### Description

- Removed `cursorHint` entries from the `Map` returned by all snippet-producing tools including `ModelTools`, `ClassTools`, `DomainTools`, `AssociationTools`, `ConstraintTools`, `StructureTools`, `TopicTools`, and `StructureAttributeTools` so each now returns only `iliSnippet` (or a single `String` where applicable).
- Deleted the `cursorHint` field and its accessor methods from the `AttributeLineResponse` model so the response class only carries `iliSnippet`.
- Updated unit tests under `src/test/java` (`ModelToolsTest`, `ClassToolsTest`, `DomainToolsTest`, `ConstraintToolsTest`, `AssociationToolsTest`, `StructureToolsTest`, `TopicToolsTest`, etc.) to remove assertions that checked `cursorHint`.
- Updated integration contract test `ToolRegistrationContractTest` and `ModelToolsIntegrationTest` to stop asserting `cursorHint` in the structured payload.

### Testing

- No automated test suite was executed as part of this change; only test code was updated to reflect the new response shape.
- A commit was created containing the source and test modifications and the repository reports the changes staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974dad03c08832884f36a9b0903af99)