### PR TITLE
Clarify INTERLIS cardinality for association roles

### DIFF
--- a/src/main/java/ch/so/agi/mcp/tools/AssociationTools.java
+++ b/src/main/java/ch/so/agi/mcp/tools/AssociationTools.java
@@ -19,10 +19,10 @@ public class AssociationTools {
   }
 
   @McpTool(name = "createAssociationSnippet",
-        description = "Erzeugt eine ASSOCIATION. Params: name (required), roles (2+ Rollen mit name,classFQN,card).")
+        description = "Erzeugt eine ASSOCIATION. Params: name (required), roles (2+ Rollen mit name,classFQN,card). card ist die Kardinalität in INTERLIS-Notation, z.B. {1}, {0..1}, {1..*}.")
   public Map<String,Object> createAssociation(
       @McpToolParam(description = "Assoziationsname", required = true) String name,
-      @McpToolParam(description = "Rollen (mindestens 2)", required = true) List<Role> roles
+      @McpToolParam(description = "Rollen (mindestens 2) mit name,classFQN,card; card ist die Kardinalität in INTERLIS-Notation, z.B. {1}, {0..1}, {1..*}.", required = true) List<Role> roles
   ) {
       
       var nv = NameValidator.ascii();


### PR DESCRIPTION
### Motivation
- Clarify what `card` means for roles passed to `createAssociationSnippet` because the previous parameter docs only listed `card` without explaining the expected INTERLIS notation.

### Description
- Update `src/main/java/ch/so/agi/mcp/tools/AssociationTools.java` to expand the `@McpTool` and `@McpToolParam` descriptions for `createAssociationSnippet` and the `roles` parameter to state that `card` is INTERLIS cardinality notation and show examples such as `{1}`, `{0..1}`, `{1..*}`.

### Testing
- No automated tests were run; this is a documentation-only change and should not affect runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ddda3eb08328ab077e057e2ec6a8)